### PR TITLE
#21 홈베이스 예약 테이블 삭제 api

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/HealthCheckWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/HealthCheckWebAdapter.kt
@@ -1,0 +1,11 @@
+package team.msg.hiv2.domain
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthCheckWebAdapter {
+
+    @GetMapping
+    fun healthCheck() = "OK"
+}

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/CommandReservationPort.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/CommandReservationPort.kt
@@ -4,4 +4,5 @@ import team.msg.hiv2.domain.reservation.domain.Reservation
 
 interface CommandReservationPort {
     fun saveReservation(reservation: Reservation): Reservation
+    fun deleteReservation(reservation: Reservation)
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
@@ -1,6 +1,7 @@
 package team.msg.hiv2.domain.reservation.application.usecase
 
 import team.msg.hiv2.domain.reservation.application.spi.ReservationPort
+import team.msg.hiv2.domain.reservation.exception.ForbiddenCommandReservationException
 import team.msg.hiv2.domain.reservation.exception.ReservationNotFoundException
 import team.msg.hiv2.domain.user.application.spi.UserPort
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
@@ -17,6 +18,10 @@ class DeleteReservationUseCase(
         val reservation = reservationPort.queryReservationById(reservationId)
             ?: throw ReservationNotFoundException()
         val users = userPort.queryAllUserByReservation(reservation)
+        val currentUser = userPort.queryCurrentUser()
+
+        if(currentUser.id != reservation.representativeId)
+            throw ForbiddenCommandReservationException()
 
         userPort.saveAll(users.map { it.copy(useStatus = UseStatus.AVAILABLE) })
         reservationPort.deleteReservation(reservation)

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
@@ -1,0 +1,7 @@
+package team.msg.hiv2.domain.reservation.application.usecase
+
+import team.msg.hiv2.global.annotation.usecase.UseCase
+
+@UseCase
+class DeleteReservationUseCase {
+}

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
@@ -1,7 +1,24 @@
 package team.msg.hiv2.domain.reservation.application.usecase
 
+import team.msg.hiv2.domain.reservation.application.spi.ReservationPort
+import team.msg.hiv2.domain.reservation.exception.ReservationNotFoundException
+import team.msg.hiv2.domain.user.application.spi.UserPort
+import team.msg.hiv2.domain.user.domain.constant.UseStatus
 import team.msg.hiv2.global.annotation.usecase.UseCase
+import java.util.UUID
 
 @UseCase
-class DeleteReservationUseCase {
+class DeleteReservationUseCase(
+    private val reservationPort: ReservationPort,
+    private val userPort: UserPort
+) {
+
+    fun execute(reservationId: UUID){
+        val reservation = reservationPort.queryReservationById(reservationId)
+            ?: throw ReservationNotFoundException()
+        val users = userPort.queryAllUserByReservation(reservation)
+
+        userPort.saveAll(users.map { it.copy(useStatus = UseStatus.AVAILABLE) })
+        reservationPort.deleteReservation(reservation)
+    }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/QueryReservationDetailUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/QueryReservationDetailUseCase.kt
@@ -1,4 +1,4 @@
-package team.msg.hiv2.domain.homebase.application.usecase
+package team.msg.hiv2.domain.reservation.application.usecase
 
 import team.msg.hiv2.domain.reservation.presentation.data.response.ReservationDetailResponse
 import team.msg.hiv2.domain.reservation.application.spi.QueryReservationPort

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/exception/ForbiddenCommandReservationException.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/exception/ForbiddenCommandReservationException.kt
@@ -1,0 +1,6 @@
+package team.msg.hiv2.domain.reservation.exception
+
+import team.msg.hiv2.global.error.ErrorCode
+import team.msg.hiv2.global.error.exception.HiException
+
+class ForbiddenCommandReservationException : HiException(ErrorCode.FORBIDDEN_COMMAND_RESERVATION)

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
@@ -21,6 +21,10 @@ class ReservationPersistenceAdapter(
     override fun saveReservation(reservation: Reservation): Reservation =
         reservationMapper.toDomain(reservationRepository.save(reservationMapper.toEntity(reservation)))!!
 
+    override fun deleteReservation(reservation: Reservation){
+        reservationRepository.deleteById(reservation.id)
+    }
+
     override fun queryReservationById(id: UUID) =
         reservationMapper.toDomain(reservationRepository.findByIdOrNull(id))
 

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import team.msg.hiv2.domain.homebase.application.usecase.QueryReservationDetailUseCase
+import team.msg.hiv2.domain.reservation.application.usecase.QueryReservationDetailUseCase
 import team.msg.hiv2.domain.reservation.presentation.data.response.ReservationDetailResponse
 import java.util.UUID
 

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
@@ -1,10 +1,12 @@
 package team.msg.hiv2.domain.reservation.presentation
 
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.msg.hiv2.domain.reservation.application.usecase.DeleteReservationUseCase
 import team.msg.hiv2.domain.reservation.application.usecase.QueryReservationDetailUseCase
 import team.msg.hiv2.domain.reservation.presentation.data.response.ReservationDetailResponse
 import java.util.UUID
@@ -12,11 +14,18 @@ import java.util.UUID
 @RestController
 @RequestMapping("/reservation")
 class ReservationWebAdapter(
-    private val queryReservationDetailUseCase: QueryReservationDetailUseCase
+    private val queryReservationDetailUseCase: QueryReservationDetailUseCase,
+    private val deleteReservationUseCase: DeleteReservationUseCase
 ) {
 
     @GetMapping("/{id}")
-    fun queryReservationById(@PathVariable id: UUID): ResponseEntity<ReservationDetailResponse> =
+    fun queryReservationDetail(@PathVariable id: UUID): ResponseEntity<ReservationDetailResponse> =
         queryReservationDetailUseCase.execute(id)
             .let { ResponseEntity.ok(it) }
+
+    @DeleteMapping("/{id}")
+    fun deleteReservation(@PathVariable id: UUID): ResponseEntity<Void> =
+        deleteReservationUseCase.execute(id)
+            .let { ResponseEntity.noContent().build() }
+
 }

--- a/src/main/kotlin/team/msg/hiv2/global/error/ErrorCode.kt
+++ b/src/main/kotlin/team/msg/hiv2/global/error/ErrorCode.kt
@@ -19,7 +19,7 @@ enum class ErrorCode(
 
     // reservation
     RESERVATION_NOT_FOUND("예약을 찾을 수 없습니다.", 404),
-    HOME_BASE_TABLE_NOT_FOUND("예약 테이블을 찾을 수 없습니다.", 404),
+    FORBIDDEN_COMMAND_RESERVATION("예약 테이블을 제어할 권한이 없습니다.", 403),
 
     // homeBase
     HOME_BASE_NOT_FOUND("홈베이스를 찾을 수 없습니다.", 404),

--- a/src/main/kotlin/team/msg/hiv2/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/msg/hiv2/global/security/SecurityConfig.kt
@@ -48,6 +48,10 @@ class SecurityConfig(
             .antMatchers(HttpMethod.POST, "/homebase").hasRole("STUDENT")
             .antMatchers(HttpMethod.GET, "/homebase").authenticated()
 
+             // reservation
+            .antMatchers(HttpMethod.GET, "/reservation/{reservation_id}").authenticated()
+            .antMatchers(HttpMethod.DELETE, "/reservation/{reservation_id}").hasRole("STUDENT")
+
              // notice
             .antMatchers(HttpMethod.POST, "/notice").hasAnyRole("ADMIN", "TEACHER")
 


### PR DESCRIPTION
## 💡 개요
홈베이스 예약 테이블 삭제 api를 개발했습니다.
## 📃 작업내용
- 홈베이스 예약 테이블 삭제
- QueryReservationDetail, DeleteReservation 유즈케이스 reservation 도메인 영역으로 이동
- 컨트롤러 메서드 byId로 끝나는 메서드들 이름 수정
- 대표자만 테이블이 삭제가능합니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
