### PR TITLE
#32 홈베이스 예약 테이블 체크 상태 변경 api

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCase.kt
@@ -35,7 +35,7 @@ class ReserveHomeBaseUseCase(
 
         userValidator.checkUsersUseStatus(users)
 
-        val reservationId = commandReservationPort.saveReservation(reservation).id
+        val reservationId = commandReservationPort.save(reservation).id
         userPort.saveAll(users.map { it.copy(reservationId = reservationId, useStatus = UseStatus.UNAVAILABLE) })
     }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/CommandReservationPort.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/CommandReservationPort.kt
@@ -3,6 +3,6 @@ package team.msg.hiv2.domain.reservation.application.spi
 import team.msg.hiv2.domain.reservation.domain.Reservation
 
 interface CommandReservationPort {
-    fun saveReservation(reservation: Reservation): Reservation
+    fun save(reservation: Reservation): Reservation
     fun deleteReservation(reservation: Reservation)
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DelegateRepresentativeUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DelegateRepresentativeUseCase.kt
@@ -25,6 +25,6 @@ class DelegateRepresentativeUseCase(
         val delegatedUser = userPort.queryUserByIdAndReservation(userId, reservation)
             ?: throw UserNotFoundException()
 
-        reservationPort.saveReservation(reservation.copy(representativeId = delegatedUser.id))
+        reservationPort.save(reservation.copy(representativeId = delegatedUser.id))
     }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationCheckStatusUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationCheckStatusUseCase.kt
@@ -1,0 +1,21 @@
+package team.msg.hiv2.domain.reservation.application.usecase
+
+import team.msg.hiv2.domain.reservation.application.spi.ReservationPort
+import team.msg.hiv2.domain.reservation.exception.ReservationNotFoundException
+import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationCheckStatusRequest
+import team.msg.hiv2.domain.user.application.spi.UserPort
+import team.msg.hiv2.global.annotation.usecase.UseCase
+import java.util.*
+
+@UseCase
+class UpdateReservationCheckStatusUseCase(
+    private val reservationPort: ReservationPort,
+    private val userPort: UserPort
+) {
+
+    fun execute(reservationId: UUID, request: UpdateReservationCheckStatusRequest){
+        val reservation = reservationPort.queryReservationById(reservationId)
+            ?: throw ReservationNotFoundException()
+        reservationPort.save(reservation.copy(checkStatus = request.checkStatus))
+    }
+}

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationCheckStatusUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationCheckStatusUseCase.kt
@@ -3,14 +3,12 @@ package team.msg.hiv2.domain.reservation.application.usecase
 import team.msg.hiv2.domain.reservation.application.spi.ReservationPort
 import team.msg.hiv2.domain.reservation.exception.ReservationNotFoundException
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationCheckStatusRequest
-import team.msg.hiv2.domain.user.application.spi.UserPort
 import team.msg.hiv2.global.annotation.usecase.UseCase
 import java.util.*
 
 @UseCase
 class UpdateReservationCheckStatusUseCase(
-    private val reservationPort: ReservationPort,
-    private val userPort: UserPort
+    private val reservationPort: ReservationPort
 ) {
 
     fun execute(reservationId: UUID, request: UpdateReservationCheckStatusRequest){

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
@@ -28,7 +28,7 @@ class UpdateReservationUseCase(
         val users = userPort.queryAllUserById(request.users)
         userValidator.checkUsersUseStatus(users)
 
-        reservationPort.saveReservation(reservation.copy(reason = request.reason))
+        reservationPort.save(reservation.copy(reason = request.reason))
         userPort.saveAll(users.map { it.copy(reservationId = reservationId) })
     }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
@@ -18,7 +18,7 @@ class ReservationPersistenceAdapter(
     private val homeBaseMapper: HomeBaseMapper
 ) : ReservationPort {
 
-    override fun saveReservation(reservation: Reservation): Reservation =
+    override fun save(reservation: Reservation): Reservation =
         reservationMapper.toDomain(reservationRepository.save(reservationMapper.toEntity(reservation)))!!
 
     override fun deleteReservation(reservation: Reservation){

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
@@ -1,16 +1,13 @@
 package team.msg.hiv2.domain.reservation.presentation
 
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import team.msg.hiv2.domain.reservation.application.usecase.*
+import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationCheckStatusRequest
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationRequest
 import team.msg.hiv2.domain.reservation.presentation.data.response.ReservationDetailResponse
 import java.util.UUID
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/reservation")
@@ -19,7 +16,8 @@ class ReservationWebAdapter(
     private val deleteReservationUseCase: DeleteReservationUseCase,
     private val updateReservationUseCase: UpdateReservationUseCase,
     private val delegateRepresentativeUseCase: DelegateRepresentativeUseCase,
-    private val exitReservationUseCase: ExitReservationUseCase
+    private val exitReservationUseCase: ExitReservationUseCase,
+    private val updateReservationCheckStatusUseCase: UpdateReservationCheckStatusUseCase
 ) {
 
     @GetMapping("/{id}")
@@ -46,5 +44,12 @@ class ReservationWebAdapter(
     fun exitReservation(@PathVariable id: UUID): ResponseEntity<Void> =
         exitReservationUseCase.execute(id)
             .let { ResponseEntity.noContent().build() }
+
+    @PatchMapping("/{id}/check-status")
+    fun updateReservationCheckStatus(@PathVariable id: UUID,
+                                     @RequestBody @Valid request: UpdateReservationCheckStatusRequest): ResponseEntity<Void> =
+        updateReservationCheckStatusUseCase.execute(id, request)
+            .let { ResponseEntity.noContent().build() }
+
 
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/request/UpdateReservationCheckStatusRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/request/UpdateReservationCheckStatusRequest.kt
@@ -1,0 +1,5 @@
+package team.msg.hiv2.domain.reservation.presentation.data.request
+
+data class UpdateReservationCheckStatusRequest(
+    val checkStatus: Boolean
+)

--- a/src/main/kotlin/team/msg/hiv2/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/msg/hiv2/global/security/SecurityConfig.kt
@@ -59,7 +59,8 @@ class SecurityConfig(
             .antMatchers(HttpMethod.DELETE, "/reservation/{reservation_id}").hasRole(STUDENT)
             .antMatchers(HttpMethod.PATCH, "/reservation/{reservation_id}").hasRole(STUDENT)
             .antMatchers(HttpMethod.PATCH, "/reservation/{reservation_id}/{user_id}").hasRole(STUDENT)
-            .antMatchers(HttpMethod.DELETE, "/reservation/{reservation_id/exit").hasRole(STUDENT)
+            .antMatchers(HttpMethod.DELETE, "/reservation/{reservation_id}/exit").hasRole(STUDENT)
+            .antMatchers(HttpMethod.PATCH, "/reservation/{reservation_id}/check-status").hasRole(TEACHER)
 
              // notice
             .antMatchers(HttpMethod.POST, "/notice").hasAnyRole(ADMIN, TEACHER)


### PR DESCRIPTION
## 💡 개요
원래는 check하기 api였는데 만약 다시 해ㅊ제할때의 상황을 고려해
checkStatus를 request로 받기로 했습니다.
## 📃 작업내용
- update reservation check status api

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
