### PR TITLE
RefreshToken Reissue Bearer 형식을 맞추지 않으면 예외를 throw

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/auth/application/usecase/ReissueTokenUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/auth/application/usecase/ReissueTokenUseCase.kt
@@ -1,23 +1,30 @@
 package team.msg.hiv2.domain.auth.application.usecase
 
 import team.msg.hiv2.domain.auth.application.spi.RefreshTokenPort
+import team.msg.hiv2.domain.auth.exception.InvalidRefreshTokenException
 import team.msg.hiv2.domain.auth.exception.RefreshTokenNotFoundException
 import team.msg.hiv2.domain.auth.presentation.data.response.TokenResponse
 import team.msg.hiv2.domain.user.application.spi.UserPort
 import team.msg.hiv2.domain.user.exception.UserNotFoundException
 import team.msg.hiv2.global.annotation.usecase.UseCase
 import team.msg.hiv2.global.security.spi.GenerateJwtPort
+import team.msg.hiv2.global.security.spi.JwtParserPort
 
 @UseCase
 class ReissueTokenUseCase(
     private val refreshTokenPort: RefreshTokenPort,
     private val userPort: UserPort,
-    private val generateJwtPort: GenerateJwtPort
+    private val generateJwtPort: GenerateJwtPort,
+    private val jwtParserPort: JwtParserPort
 ) {
 
-    fun execute(refreshToken: String): TokenResponse {
+    fun execute(requestToken: String): TokenResponse {
+        val refreshToken = jwtParserPort.parseRefreshToken(requestToken)
+            ?: throw InvalidRefreshTokenException()
+
         val token = refreshTokenPort.queryByRefreshToken(refreshToken)
             ?: throw RefreshTokenNotFoundException()
+
         val user = userPort.queryUserById(token.userId) ?: throw UserNotFoundException()
         return generateJwtPort.generate(user.id, user.roles)
     }

--- a/src/main/kotlin/team/msg/hiv2/domain/auth/exception/InvalidRefreshTokenException.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/auth/exception/InvalidRefreshTokenException.kt
@@ -1,0 +1,7 @@
+package team.msg.hiv2.domain.auth.exception
+
+import team.msg.hiv2.global.error.ErrorCode
+import team.msg.hiv2.global.error.exception.HiException
+
+class InvalidRefreshTokenException : HiException(ErrorCode.INVALID_TOKEN) {
+}


### PR DESCRIPTION
## 💡 개요
RefreshToken을 Bearer형식을 맞추도록 usecase 리팩터링

## 📃 작업내용

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
