### PR TITLE
95 feat/schedule reservation

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/scheduler/ReservationScheduler.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/scheduler/ReservationScheduler.kt
@@ -1,0 +1,55 @@
+package team.msg.hiv2.domain.reservation.application.scheduler
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import team.msg.hiv2.domain.homebase.application.service.HomeBaseService
+import team.msg.hiv2.domain.homebase.application.usecase.DeleteAllReservationByPeriodUseCase
+import team.msg.hiv2.domain.reservation.application.service.ReservationService
+import team.msg.hiv2.domain.reservation.application.usecase.CheckAndRestrictReservationUserUseCase
+
+@Component
+class ReservationScheduler(
+    private val deleteAllReservationByPeriodUseCase: DeleteAllReservationByPeriodUseCase,
+    private val checkAndRestrictReservationUserUseCase: CheckAndRestrictReservationUserUseCase,
+    private val reservationService: ReservationService,
+    private val homeBaseService: HomeBaseService
+) {
+
+    /**
+     * 매일 5시 30분에 8교시 예약 테이블 삭제와 유저 정지 여부 검증
+     */
+    @Scheduled(cron = "0 30 17 * * *", zone = "Asia/Seoul")
+    fun resetAll8PeriodReservation() = checkAndDelete(8)
+
+
+    /**
+     * 매일 6시 30분에 8교시 예약 테이블 삭제와 유저 정지 여부 검증
+     */
+    @Scheduled(cron = "0 30 18 * * *", zone = "Asia/Seoul")
+    fun resetAll9PeriodReservation() = checkAndDelete(9)
+
+    /**
+     * 매일 8시 20분에 8교시 예약 테이블 삭제와 유저 정지 여부 검증
+     */
+    @Scheduled(cron = "0 20 20 * * *", zone = "Asia/Seoul")
+    fun resetAll10PeriodReservation() = checkAndDelete(10)
+
+    /**
+     * 매일 9시 20분에 8교시 예약 테이블 삭제와 유저 정지 여부 검증
+     */
+    @Scheduled(cron = "0 20 21 * * *", zone = "Asia/Seoul")
+    fun resetAll11PeriodReservation() = checkAndDelete(11)
+
+    private fun checkAndDelete(period: Int){
+
+        val homeBases = homeBaseService.queryAllHomeBaseByPeriod(period)
+
+        val reservations = reservationService.queryAllReservationByHomeBaseIn(homeBases)
+
+        reservations.forEach {
+            checkAndRestrictReservationUserUseCase.execute(it.id)
+        }
+
+        deleteAllReservationByPeriodUseCase.execute(period)
+    }
+}

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/CheckAndRestrictReservationUserUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/CheckAndRestrictReservationUserUseCase.kt
@@ -1,0 +1,24 @@
+package team.msg.hiv2.domain.reservation.application.usecase
+
+import team.msg.hiv2.domain.reservation.application.service.ReservationService
+import team.msg.hiv2.domain.user.application.service.UserService
+import team.msg.hiv2.domain.user.domain.constant.UseStatus
+import team.msg.hiv2.global.annotation.usecase.UseCase
+import java.util.UUID
+
+@UseCase
+class CheckAndRestrictReservationUserUseCase(
+    private val userService: UserService,
+    private val reservationService: ReservationService
+) {
+
+    fun execute(id: UUID){
+        val reservation = reservationService.queryReservationById(id)
+
+        val users = userService.queryAllUserByReservation(reservation)
+
+        if(!reservation.checkStatus) {
+            userService.saveAll(users.map { it.copy(useStatus = UseStatus.UNAVAILABLE) })
+        }
+    }
+}

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/domain/constant/CheckStatus.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/domain/constant/CheckStatus.kt
@@ -1,5 +1,0 @@
-package team.msg.hiv2.domain.reservation.domain.constant
-
-enum class CheckStatus {
-    CHECKED, UNCHECKED
-}

--- a/src/main/kotlin/team/msg/hiv2/global/config/EnableSchedulingConfig.kt
+++ b/src/main/kotlin/team/msg/hiv2/global/config/EnableSchedulingConfig.kt
@@ -1,0 +1,8 @@
+package team.msg.hiv2.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@EnableScheduling
+@Configuration
+class EnableSchedulingConfig


### PR DESCRIPTION
## 💡 개요
시간이 지날때마다 교시별 홈베이스 예약 초기화와 확인되지 않은 테이블 정지 검증 작업 스케쥴링
+ enum타입의 checkStatus가 있었는데 삭제
## 📃 작업내용

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
