### PR TITLE
115 refactor/web request

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/auth/presentation/AuthWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/auth/presentation/AuthWebAdapter.kt
@@ -9,6 +9,7 @@ import team.msg.hiv2.domain.auth.application.usecase.ReissueTokenUseCase
 import team.msg.hiv2.domain.auth.presentation.data.request.GAuthSignInRequest
 import team.msg.hiv2.domain.auth.presentation.data.response.GAuthLinkResponse
 import team.msg.hiv2.domain.auth.presentation.data.response.TokenResponse
+import team.msg.hiv2.domain.auth.presentation.data.web.GAuthSignInWebRequest
 import javax.validation.Valid
 
 @RestController
@@ -26,8 +27,10 @@ class AuthWebAdapter(
             .let { ResponseEntity.ok(it) }
 
     @PostMapping
-    fun signIn(@RequestBody @Valid request: GAuthSignInRequest): ResponseEntity<TokenResponse> =
-        gAuthSignInUseCase.execute(request)
+    fun signIn(@RequestBody @Valid request: GAuthSignInWebRequest): ResponseEntity<TokenResponse> =
+        gAuthSignInUseCase.execute(
+            GAuthSignInRequest(request.code)
+        )
             .let { ResponseEntity.ok(it) }
 
     @PatchMapping

--- a/src/main/kotlin/team/msg/hiv2/domain/auth/presentation/data/request/GAuthSignInRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/auth/presentation/data/request/GAuthSignInRequest.kt
@@ -1,8 +1,5 @@
 package team.msg.hiv2.domain.auth.presentation.data.request
 
-import javax.validation.constraints.NotNull
-
 data class GAuthSignInRequest(
-    @field:NotNull
     val code: String
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/auth/presentation/data/web/GAuthSignInWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/auth/presentation/data/web/GAuthSignInWebRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.hiv2.domain.auth.presentation.data.web
+
+import javax.validation.constraints.NotNull
+
+data class GAuthSignInWebRequest(
+    @field:NotNull
+    val code: String
+)

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/HomeBaseWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/HomeBaseWebAdapter.kt
@@ -13,6 +13,7 @@ import team.msg.hiv2.domain.homebase.application.usecase.DeleteAllReservationByP
 import team.msg.hiv2.domain.homebase.application.usecase.QueryReservationByHomeBaseUseCase
 import team.msg.hiv2.domain.homebase.application.usecase.ReserveHomeBaseUseCase
 import team.msg.hiv2.domain.homebase.presentation.data.request.ReservationHomeBaseRequest
+import team.msg.hiv2.domain.homebase.presentation.data.web.ReservationHomeBaseWebRequest
 import team.msg.hiv2.domain.reservation.presentation.data.response.ReservationResponse
 import javax.validation.Valid
 
@@ -27,8 +28,8 @@ class HomeBaseWebAdapter(
     @PostMapping
     fun reserveHomeBase(@RequestParam floor: Int,
                         @RequestParam period: Int,
-                        @Valid @RequestBody request: ReservationHomeBaseRequest): ResponseEntity<Void> =
-        reserveHomeBaseUseCase.execute(floor, period, request)
+                        @Valid @RequestBody request: ReservationHomeBaseWebRequest): ResponseEntity<Void> =
+        reserveHomeBaseUseCase.execute(floor, period, ReservationHomeBaseRequest(request.users, request.reason))
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 
     @GetMapping

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/request/ReservationHomeBaseRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/request/ReservationHomeBaseRequest.kt
@@ -1,12 +1,8 @@
 package team.msg.hiv2.domain.homebase.presentation.data.request
 
 import java.util.UUID
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.Size
 
 data class ReservationHomeBaseRequest(
-    @field:Size(min = 2, max = 6)
     val users: MutableList<UUID>,
-    @field:NotBlank
     val reason: String
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/web/ReservationHomeBaseWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/web/ReservationHomeBaseWebRequest.kt
@@ -1,0 +1,12 @@
+package team.msg.hiv2.domain.homebase.presentation.data.web
+
+import java.util.*
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class ReservationHomeBaseWebRequest(
+    @field:Size(min = 2, max = 6)
+    val users: MutableList<UUID>,
+    @field:NotBlank
+    val reason: String
+)

--- a/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/NoticeWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/NoticeWebAdapter.kt
@@ -15,6 +15,8 @@ import team.msg.hiv2.domain.notice.presentation.data.request.CreateNoticeRequest
 import team.msg.hiv2.domain.notice.presentation.data.request.UpdateNoticeRequest
 import team.msg.hiv2.domain.notice.presentation.data.response.NoticeDetailsResponse
 import team.msg.hiv2.domain.notice.presentation.data.response.NoticeResponse
+import team.msg.hiv2.domain.notice.presentation.data.web.CreateNoticeWebRequest
+import team.msg.hiv2.domain.notice.presentation.data.web.UpdateNoticeWebRequest
 import java.util.UUID
 import javax.validation.Valid
 
@@ -29,8 +31,13 @@ class NoticeWebAdapter(
 ) {
 
     @PostMapping
-    fun createNotice(@RequestBody @Valid request: CreateNoticeRequest): ResponseEntity<Void> =
-        createNoticeUseCase.execute(request)
+    fun createNotice(@RequestBody @Valid request: CreateNoticeWebRequest): ResponseEntity<Void> =
+        createNoticeUseCase.execute(
+            CreateNoticeRequest(
+                title = request.title,
+                content = request.content
+            )
+        )
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 
     @GetMapping
@@ -49,7 +56,12 @@ class NoticeWebAdapter(
             .let { ResponseEntity.noContent().build() }
 
     @PatchMapping("/{id}")
-    fun updateNotice(@PathVariable id: UUID, @RequestBody @Valid request: UpdateNoticeRequest): ResponseEntity<Void> =
-        updateNoticeUseCase.execute(id, request)
+    fun updateNotice(@PathVariable id: UUID, @RequestBody @Valid request: UpdateNoticeWebRequest): ResponseEntity<Void> =
+        updateNoticeUseCase.execute(id,
+            UpdateNoticeRequest(
+                title = request.title,
+                content = request.content
+            )
+        )
             .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/request/CreateNoticeRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/request/CreateNoticeRequest.kt
@@ -1,10 +1,6 @@
 package team.msg.hiv2.domain.notice.presentation.data.request
 
-import javax.validation.constraints.NotBlank
-
 data class CreateNoticeRequest(
-    @field:NotBlank
     val title: String,
-    @field:NotBlank
-    val content: String,
+    val content: String
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/request/UpdateNoticeRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/request/UpdateNoticeRequest.kt
@@ -1,10 +1,7 @@
 package team.msg.hiv2.domain.notice.presentation.data.request
 
-import javax.validation.constraints.NotEmpty
 
 data class UpdateNoticeRequest(
-    @field:NotEmpty
     val title: String,
-    @field:NotEmpty
     val content: String
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/web/CreateNoticeWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/web/CreateNoticeWebRequest.kt
@@ -1,0 +1,10 @@
+package team.msg.hiv2.domain.notice.presentation.data.web
+
+import javax.validation.constraints.NotBlank
+
+data class CreateNoticeWebRequest(
+    @field:NotBlank
+    val title: String,
+    @field:NotBlank
+    val content: String
+)

--- a/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/web/UpdateNoticeWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/notice/presentation/data/web/UpdateNoticeWebRequest.kt
@@ -1,0 +1,10 @@
+package team.msg.hiv2.domain.notice.presentation.data.web
+
+import javax.validation.constraints.NotEmpty
+
+data class UpdateNoticeWebRequest(
+    @field:NotEmpty
+    val title: String,
+    @field:NotEmpty
+    val content: String
+)

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/ReservationWebAdapter.kt
@@ -6,6 +6,8 @@ import team.msg.hiv2.domain.reservation.application.usecase.*
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationCheckStatusRequest
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationRequest
 import team.msg.hiv2.domain.reservation.presentation.data.response.ReservationDetailResponse
+import team.msg.hiv2.domain.reservation.presentation.data.web.UpdateReservationCheckStatusWebRequest
+import team.msg.hiv2.domain.reservation.presentation.data.web.UpdateReservationWebRequest
 import java.util.UUID
 import javax.validation.Valid
 
@@ -31,8 +33,13 @@ class ReservationWebAdapter(
         deleteReservationUseCase.execute(id)
             .let { ResponseEntity.noContent().build() }
     @PatchMapping("/{id}")
-    fun updateReservation(@PathVariable id: UUID, request: UpdateReservationRequest): ResponseEntity<Void> =
-        updateReservationUseCase.execute(id, request)
+    fun updateReservation(@PathVariable id: UUID, request: UpdateReservationWebRequest): ResponseEntity<Void> =
+        updateReservationUseCase.execute(id,
+            UpdateReservationRequest(
+                users = request.users,
+                reason = request.reason
+            )
+        )
             .let { ResponseEntity.noContent().build() }
 
     @PatchMapping("/{id}/{user_id}")
@@ -47,8 +54,12 @@ class ReservationWebAdapter(
 
     @PatchMapping("/{id}/check-status")
     fun updateReservationCheckStatus(@PathVariable id: UUID,
-                                     @RequestBody @Valid request: UpdateReservationCheckStatusRequest): ResponseEntity<Void> =
-        updateReservationCheckStatusUseCase.execute(id, request)
+                                     @RequestBody @Valid request: UpdateReservationCheckStatusWebRequest): ResponseEntity<Void> =
+        updateReservationCheckStatusUseCase.execute(id,
+            UpdateReservationCheckStatusRequest(
+                request.checkStatus
+            )
+        )
             .let { ResponseEntity.noContent().build() }
 
     @DeleteMapping("/kill-all")

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/request/UpdateReservationRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/request/UpdateReservationRequest.kt
@@ -1,12 +1,8 @@
 package team.msg.hiv2.domain.reservation.presentation.data.request
 
 import java.util.*
-import javax.validation.constraints.NotBlank
-import javax.validation.constraints.Size
 
 data class UpdateReservationRequest(
-    @field:Size(min = 2, max = 6)
     val users: List<UUID>,
-    @field:NotBlank
     val reason: String
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/web/UpdateReservationCheckStatusWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/web/UpdateReservationCheckStatusWebRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.hiv2.domain.reservation.presentation.data.web
+
+import javax.validation.constraints.NotNull
+
+data class UpdateReservationCheckStatusWebRequest(
+    @field:NotNull
+    val checkStatus: Boolean
+)

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/web/UpdateReservationWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/web/UpdateReservationWebRequest.kt
@@ -1,0 +1,12 @@
+package team.msg.hiv2.domain.reservation.presentation.data.web
+
+import java.util.*
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class UpdateReservationWebRequest(
+    @field:Size(min = 2, max = 6)
+    val users: List<UUID>,
+    @field:NotBlank
+    val reason: String
+)

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCase.kt
@@ -1,6 +1,7 @@
 package team.msg.hiv2.domain.user.application.usecase
 
 import team.msg.hiv2.domain.user.application.service.UserService
+import team.msg.hiv2.domain.user.presentation.data.request.SearchUserKeywordRequest
 import team.msg.hiv2.domain.user.presentation.data.response.UserResponse
 import team.msg.hiv2.global.annotation.usecase.ReadOnlyUseCase
 
@@ -9,8 +10,8 @@ class SearchUserByNameKeywordUseCase(
     private val userService: UserService
 ) {
 
-    fun execute(keyword: String): List<UserResponse> =
-        userService.queryUserByNameContaining(keyword).map {
+    fun execute(request: SearchUserKeywordRequest): List<UserResponse> =
+        userService.queryUserByNameContaining(request.keyword).map {
             UserResponse(
                 userId = it.id,
                 name = it.name,

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/UpdateUserUseStatusUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/UpdateUserUseStatusUseCase.kt
@@ -2,6 +2,7 @@ package team.msg.hiv2.domain.user.application.usecase
 
 import team.msg.hiv2.domain.user.application.service.UserService
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
+import team.msg.hiv2.domain.user.presentation.data.request.UpdateUserUseStatusRequest
 import team.msg.hiv2.global.annotation.usecase.UseCase
 import java.util.UUID
 
@@ -9,9 +10,9 @@ import java.util.UUID
 class UpdateUserUseStatusUseCase(
     private val userService: UserService
 ) {
-    fun execute(userId: UUID, status: UseStatus) {
+    fun execute(userId: UUID, request: UpdateUserUseStatusRequest) {
         val user = userService.queryUserById(userId)
 
-        userService.save(user.copy(useStatus = status))
+        userService.save(user.copy(useStatus = request.status))
     }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/UserWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/UserWebAdapter.kt
@@ -16,6 +16,8 @@ import team.msg.hiv2.domain.user.presentation.data.request.UpdateUserUseStatusRe
 import team.msg.hiv2.domain.user.presentation.data.response.AllStudentsResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserInfoResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserResponse
+import team.msg.hiv2.domain.user.presentation.data.web.SearchUserKeywordWebRequest
+import team.msg.hiv2.domain.user.presentation.data.web.UpdateUserUseStatusWebRequest
 import java.util.UUID
 import javax.validation.Valid
 
@@ -29,8 +31,12 @@ class UserWebAdapter(
 ) {
 
     @GetMapping("/search")
-    fun searchUser(@RequestBody @Valid request: SearchUserKeywordRequest): ResponseEntity<List<UserResponse>> =
-        searchUserByNameKeywordUseCase.execute(request.keyword)
+    fun searchUser(@RequestBody @Valid request: SearchUserKeywordWebRequest): ResponseEntity<List<UserResponse>> =
+        searchUserByNameKeywordUseCase.execute(
+            SearchUserKeywordRequest(
+                keyword = request.keyword
+            )
+        )
             .let { ResponseEntity.ok(it) }
 
     @GetMapping("/my-page")
@@ -44,7 +50,11 @@ class UserWebAdapter(
             .let { ResponseEntity.ok(it) }
 
     @PatchMapping("/{id}")
-    fun updateUserUseStatus(@PathVariable id: UUID, updateUserUseStatusRequest: UpdateUserUseStatusRequest): ResponseEntity<Void> =
-        updateUserUseStatusUseCase.execute(id, updateUserUseStatusRequest.status)
+    fun updateUserUseStatus(@PathVariable id: UUID, request: UpdateUserUseStatusWebRequest): ResponseEntity<Void> =
+        updateUserUseStatusUseCase.execute(id,
+            UpdateUserUseStatusRequest(
+                status = request.status
+            )
+        )
             .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/request/SearchUserKeywordRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/request/SearchUserKeywordRequest.kt
@@ -1,8 +1,6 @@
 package team.msg.hiv2.domain.user.presentation.data.request
 
-import javax.validation.constraints.NotNull
 
 data class SearchUserKeywordRequest(
-    @field:NotNull
     val keyword: String
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/request/UpdateUserUseStatusRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/request/UpdateUserUseStatusRequest.kt
@@ -1,10 +1,7 @@
 package team.msg.hiv2.domain.user.presentation.data.request
 
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
 
 class UpdateUserUseStatusRequest(
-    @field:Enumerated(EnumType.STRING)
     val status: UseStatus
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/web/SearchUserKeywordWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/web/SearchUserKeywordWebRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.hiv2.domain.user.presentation.data.web
+
+import javax.validation.constraints.NotNull
+
+data class SearchUserKeywordWebRequest(
+    @field:NotNull
+    val keyword: String
+)

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/web/UpdateUserUseStatusWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/web/UpdateUserUseStatusWebRequest.kt
@@ -1,0 +1,10 @@
+package team.msg.hiv2.domain.user.presentation.data.web
+
+import team.msg.hiv2.domain.user.domain.constant.UseStatus
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+
+data class UpdateUserUseStatusWebRequest(
+    @field:Enumerated(EnumType.STRING)
+    val status: UseStatus
+)

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
@@ -11,6 +11,7 @@ import team.msg.hiv2.domain.user.application.service.UserService
 import team.msg.hiv2.domain.user.domain.User
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
 import team.msg.hiv2.domain.user.domain.constant.UserRole
+import team.msg.hiv2.domain.user.presentation.data.request.SearchUserKeywordRequest
 import team.msg.hiv2.domain.user.presentation.data.response.UserResponse
 import team.msg.hiv2.global.annotation.HiTest
 import java.util.*
@@ -22,8 +23,6 @@ class SearchUserByNameKeywordUseCaseTest {
     private lateinit var userService: UserService
 
     private lateinit var searchUserByNameKeywordUseCase: SearchUserByNameKeywordUseCase
-
-    private val requestKeyword = "김"
 
     private val userStub by lazy {
         User(
@@ -50,6 +49,12 @@ class SearchUserByNameKeywordUseCaseTest {
         )
     }
 
+    private val requestStub by lazy {
+        SearchUserKeywordRequest(
+            keyword = "김"
+        )
+    }
+
     @BeforeEach
     fun setUp() {
         searchUserByNameKeywordUseCase =
@@ -59,11 +64,11 @@ class SearchUserByNameKeywordUseCaseTest {
     @Test
     fun `유저 검색 성공`() {
         // given
-        given(userService.queryUserByNameContaining(requestKeyword))
+        given(userService.queryUserByNameContaining(requestStub.keyword))
             .willReturn(listOf(userStub))
 
         // when
-        val result = searchUserByNameKeywordUseCase.execute(requestKeyword)
+        val result = searchUserByNameKeywordUseCase.execute(requestStub)
 
         // then
         assertThat(result).isEqualTo(listOf(responseStub))

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/UpdateUserUseStatusUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/UpdateUserUseStatusUseCaseTest.kt
@@ -9,6 +9,7 @@ import team.msg.hiv2.domain.user.application.service.UserService
 import team.msg.hiv2.domain.user.domain.User
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
 import team.msg.hiv2.domain.user.domain.constant.UserRole
+import team.msg.hiv2.domain.user.presentation.data.request.UpdateUserUseStatusRequest
 import team.msg.hiv2.global.annotation.HiTest
 import java.util.*
 
@@ -37,7 +38,11 @@ internal class UpdateUserUseStatusUseCaseTest {
         )
     }
 
-    private val requestStub = UseStatus.UNAVAILABLE
+    private val requestStub by lazy {
+        UpdateUserUseStatusRequest(
+            status = UseStatus.UNAVAILABLE
+        )
+    }
 
     @BeforeEach
     fun setUp() {
@@ -55,7 +60,7 @@ internal class UpdateUserUseStatusUseCaseTest {
 
         // when & then
         assertDoesNotThrow {
-            updateUserUseStatusUserService.execute(userId ,requestStub)
+            updateUserUseStatusUserService.execute(userId, requestStub)
         }
     }
 


### PR DESCRIPTION
## 💡 개요
- WebAdapter에서 받는 request를 webRequest로 분리
- WebAdapter에서 받은 request를 Application Layer Request를 생성해 인자로 넣습니다.

## 📃 작업내용
모든 DomainWebAdapter의 request, web request

## 🔀 변경사항
SearchUserUseCase와 UpdateUserUseStatusUseCase가 reqeust의 필드를 인자로 받던데 그냥
request를 받아서 처리하도록 수정했습니다. 테스트코드도 그에 맞춰서 수정했습니다.

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타

