### PR TITLE
#142 홈베이스 예약 테이블 번호 필드 추가 작업

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCase.kt
@@ -1,6 +1,7 @@
 package team.msg.hiv2.domain.homebase.application.usecase
 
 import team.msg.hiv2.domain.homebase.application.service.HomeBaseService
+import team.msg.hiv2.domain.homebase.exception.AlreadyExistReservationException
 import team.msg.hiv2.domain.homebase.exception.ForbiddenReserveException
 import team.msg.hiv2.domain.homebase.presentation.data.request.ReservationHomeBaseRequest
 import team.msg.hiv2.domain.reservation.application.service.ReservationService
@@ -28,6 +29,9 @@ class ReserveHomeBaseUseCase(
 
         if(reservationService.countReservationByHomeBase(homeBase) >= 5)
             throw ForbiddenReserveException()
+
+        if(reservationService.existsByHomeBaseAndReservationNumber(homeBase, request.reservationNumber))
+            throw AlreadyExistReservationException()
 
         val reservationId = reservationService.save(
             Reservation(

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCase.kt
@@ -35,7 +35,8 @@ class ReserveHomeBaseUseCase(
                 reason = request.reason,
                 representativeId = currentUser.id,
                 homeBaseId = homeBase.id,
-                checkStatus = false
+                checkStatus = false,
+                reservationNumber = request.reservationNumber
             )
         ).id
 

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/exception/AlreadyExistReservationException.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/exception/AlreadyExistReservationException.kt
@@ -1,0 +1,6 @@
+package team.msg.hiv2.domain.homebase.exception
+
+import team.msg.hiv2.global.error.ErrorCode
+import team.msg.hiv2.global.error.exception.HiException
+
+class AlreadyExistReservationException : HiException(ErrorCode.ALREADY_EXIST_RESERVATION)

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/HomeBaseWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/HomeBaseWebAdapter.kt
@@ -28,7 +28,7 @@ class HomeBaseWebAdapter(
     fun reserveHomeBase(@RequestParam floor: Int,
                         @RequestParam period: Int,
                         @Valid @RequestBody request: ReservationHomeBaseWebRequest): ResponseEntity<Void> =
-        homeBaseFacade.reserveHomeBase(floor, period, ReservationHomeBaseRequest(request.users, request.reason))
+        homeBaseFacade.reserveHomeBase(floor, period, ReservationHomeBaseRequest(request.users, request.reason, request.reservationNumber))
             .let { ResponseEntity.status(HttpStatus.CREATED).build() }
 
     @GetMapping

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/request/ReservationHomeBaseRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/request/ReservationHomeBaseRequest.kt
@@ -4,5 +4,6 @@ import java.util.UUID
 
 data class ReservationHomeBaseRequest(
     val users: MutableList<UUID>,
-    val reason: String
+    val reason: String,
+    val reservationNumber: Int
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/web/ReservationHomeBaseWebRequest.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/presentation/data/web/ReservationHomeBaseWebRequest.kt
@@ -1,5 +1,7 @@
 package team.msg.hiv2.domain.homebase.presentation.data.web
 
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 import java.util.*
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
@@ -8,5 +10,8 @@ data class ReservationHomeBaseWebRequest(
     @field:Size(min = 2, max = 6)
     val users: MutableList<UUID>,
     @field:NotBlank
-    val reason: String
+    val reason: String,
+    @field:Min(1, message = "Value must be between 1 and 6")
+    @field:Max(6, message = "Value must be between 1 and 6")
+    val reservationNumber: Int
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationService.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationService.kt
@@ -10,4 +10,5 @@ interface QueryReservationService {
     fun queryAllReservationByHomeBase(homeBase: HomeBase): List<Reservation>
     fun queryAllReservationByHomeBaseIn(homeBases: List<HomeBase>): List<Reservation>
     fun countReservationByHomeBase(homeBase: HomeBase): Int
+    fun existsByHomeBaseAndReservationNumber(homeBase: HomeBase, reservationNumber: Int): Boolean
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationServiceImpl.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationServiceImpl.kt
@@ -8,7 +8,7 @@ import team.msg.hiv2.global.annotation.service.DomainService
 import java.util.*
 
 @DomainService
-private class QueryReservationServiceImpl(
+class QueryReservationServiceImpl(
     private val queryReservationPort: QueryReservationPort
 ) : QueryReservationService {
 
@@ -23,4 +23,9 @@ private class QueryReservationServiceImpl(
 
     override fun countReservationByHomeBase(homeBase: HomeBase): Int =
         queryReservationPort.countReservationByHomeBase(homeBase)
+
+    override fun existsByHomeBaseAndReservationNumber(homeBase: HomeBase,reservationNumber: Int): Boolean =
+        queryReservationPort.existsByHomeBaseAndReservationNumber(homeBase, reservationNumber)
+
+
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/QueryReservationPort.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/QueryReservationPort.kt
@@ -9,4 +9,5 @@ interface QueryReservationPort {
     fun queryAllReservationByHomeBase(homeBase: HomeBase): List<Reservation>
     fun queryAllReservationByHomeBaseIn(homeBases: List<HomeBase>): List<Reservation>
     fun countReservationByHomeBase(homeBase: HomeBase): Int
+    fun existsByHomeBaseAndReservationNumber(homeBase: HomeBase, reservationNumber: Int): Boolean
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/domain/Reservation.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/domain/Reservation.kt
@@ -10,5 +10,6 @@ data class Reservation(
     val representativeId: UUID,
     val homeBaseId: Long,
     val reason: String,
-    val checkStatus: Boolean
+    val checkStatus: Boolean,
+    val reservationNumber: Int
 )

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
@@ -46,5 +46,8 @@ class ReservationPersistenceAdapter(
     override fun countReservationByHomeBase(homeBase: HomeBase): Int =
         reservationRepository.countByHomeBase(homeBaseMapper.toEntity(homeBase))
 
+    override fun existsByHomeBaseAndReservationNumber(homeBase: HomeBase,reservationNumber: Int): Boolean =
+        reservationRepository.existsByHomeBaseAndReservationNumber(homeBaseMapper.toEntity(homeBase), reservationNumber)
+
 
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/entity/ReservationJpaEntity.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/entity/ReservationJpaEntity.kt
@@ -8,7 +8,7 @@ import java.util.*
 import javax.persistence.*
 
 @Entity
-@Table(name = "reservation")
+@Table(name = "reservation", uniqueConstraints = [UniqueConstraint(columnNames = ["home_base_id", "reservation_number"])])
 class ReservationJpaEntity(
 
     override val id: UUID,
@@ -25,7 +25,9 @@ class ReservationJpaEntity(
     val reason: String,
 
     @Column(name = "check_status", nullable = false)
-    var checkStatus: Boolean = false
+    var checkStatus: Boolean = false,
 
+    @Column(name = "reservation_number", nullable = false)
+    val reservationNumber: Int
 
 ) : BaseUuidEntity(id)

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/mapper/ReservationMapper.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/mapper/ReservationMapper.kt
@@ -23,7 +23,8 @@ class ReservationMapper(
                 representativeId = it.user.id,
                 homeBaseId = it.homeBase.id,
                 reason = it.reason,
-                checkStatus = it.checkStatus
+                checkStatus = it.checkStatus,
+                reservationNumber = it.reservationNumber
             )
         }
 
@@ -38,7 +39,8 @@ class ReservationMapper(
                 user = user,
                 homeBase = homeBase,
                 reason = it.reason,
-                checkStatus = it.checkStatus
+                checkStatus = it.checkStatus,
+                reservationNumber = it.reservationNumber
             )
         }
     }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/repository/ReservationRepository.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/repository/ReservationRepository.kt
@@ -15,4 +15,5 @@ interface ReservationRepository : CrudRepository<ReservationJpaEntity, UUID> {
     @Query("DELETE FROM ReservationJpaEntity r WHERE r IN :reservations")
     fun deleteAllInBatch(reservations: List<ReservationJpaEntity>)
     fun countByHomeBase(homeBase: HomeBaseJpaEntity): Int
+    fun existsByHomeBaseAndReservationNumber(homeBase: HomeBaseJpaEntity, reservationNumber: Int): Boolean
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/response/ReservationDetailResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/response/ReservationDetailResponse.kt
@@ -8,14 +8,16 @@ data class ReservationDetailResponse(
     val reservationId: UUID,
     val users: List<UserResponse>,
     val reason: String,
-    val checkStatus: Boolean
+    val checkStatus: Boolean,
+    val reservationNumber: Int
 ) {
     companion object {
         fun of(reservation: Reservation, users: List<UserResponse>) = ReservationDetailResponse(
             reservationId = reservation.id,
             users = users,
             reason = reservation.reason,
-            checkStatus = reservation.checkStatus
+            checkStatus = reservation.checkStatus,
+            reservationNumber = reservation.reservationNumber
         )
     }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/response/ReservationResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/presentation/data/response/ReservationResponse.kt
@@ -6,12 +6,14 @@ import java.util.*
 
 data class ReservationResponse(
     val reservationId: UUID,
-    val users: List<UserResponse>
+    val users: List<UserResponse>,
+    val reservationNumber: Int
 ) {
     companion object {
         fun of(reservation: Reservation, users: List<UserResponse>) = ReservationResponse(
             reservationId = reservation.id,
-            users = users
+            users = users,
+            reservationNumber = reservation.reservationNumber
         )
     }
 }

--- a/src/main/kotlin/team/msg/hiv2/global/error/ErrorCode.kt
+++ b/src/main/kotlin/team/msg/hiv2/global/error/ErrorCode.kt
@@ -21,6 +21,7 @@ enum class ErrorCode(
     RESERVATION_NOT_FOUND("예약을 찾을 수 없습니다.", 404),
     FORBIDDEN_COMMAND_RESERVATION("예약 테이블을 제어할 권한이 없습니다.", 403),
     FORBIDDEN_EXIT_RESERVATION("대표자는 예약을 나갈 수 없습니다.", 403),
+    ALREADY_EXIST_RESERVATION("이미 예약 되어진 자리입니다.", 403),
 
     // homeBase
     HOME_BASE_NOT_FOUND("홈베이스를 찾을 수 없습니다.", 404),

--- a/src/test/kotlin/team/msg/hiv2/domain/homebase/application/usecase/QueryReservationByHomeBaseUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/homebase/application/usecase/QueryReservationByHomeBaseUseCaseTest.kt
@@ -35,6 +35,7 @@ class QueryReservationByHomeBaseUseCaseTest {
     private val floor = 3
     private val period = 10
     private val homeBaseId: Long = 1
+    private val reservationNumber = 1
 
     private val representativeId1 = UUID.randomUUID()
     private val userId1 = UUID.randomUUID()
@@ -57,7 +58,8 @@ class QueryReservationByHomeBaseUseCaseTest {
             representativeId = representativeId1,
             homeBaseId = homeBaseId,
             reason = reason,
-            checkStatus = false
+            checkStatus = false,
+            reservationNumber = reservationNumber
         )
     }
 
@@ -118,7 +120,8 @@ class QueryReservationByHomeBaseUseCaseTest {
             users = listOf(
                 userResponseStub1,
                 userResponseStub2
-            )
+            ),
+            reservationNumber = reservationNumber
         )
     }
 

--- a/src/test/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCaseTest.kt
@@ -38,6 +38,7 @@ internal class ReserveHomeBaseUseCaseTest {
     private val floor = 3
     private val period = 10
     private val reason = "회의"
+    private val reservationNumber = 1
 
     private val userId = UUID.randomUUID()
     private val userId2 = UUID.randomUUID()
@@ -45,7 +46,8 @@ internal class ReserveHomeBaseUseCaseTest {
     private val requestStub by lazy {
         ReservationHomeBaseRequest(
             mutableListOf(userId, userId2),
-            reason
+            reason,
+            reservationNumber
         )
     }
 
@@ -63,7 +65,8 @@ internal class ReserveHomeBaseUseCaseTest {
             homeBaseId = homeBaseStub.id,
             representativeId = userId,
             reason = reason,
-            checkStatus = false
+            checkStatus = false,
+            reservationNumber = reservationNumber
         )
     }
 

--- a/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DelegateRepresentativeUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DelegateRepresentativeUseCaseTest.kt
@@ -30,6 +30,7 @@ class DelegateRepresentativeUseCaseTest {
     private val reservationId = UUID.randomUUID()
     private val representativeId = UUID.randomUUID()
     private val userId = UUID.randomUUID()
+    private val reservationNumber = 1
 
     private val homeBaseStub by lazy {
         HomeBase(
@@ -45,7 +46,8 @@ class DelegateRepresentativeUseCaseTest {
             representativeId = representativeId,
             reason = "reason",
             homeBaseId = homeBaseStub.id,
-            checkStatus = false
+            checkStatus = false,
+            reservationNumber = reservationNumber
         )
     }
 

--- a/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCaseTest.kt
@@ -32,6 +32,7 @@ class DeleteReservationUseCaseTest {
 
     private val representativeId = UUID.randomUUID()
     private val userId = UUID.randomUUID()
+    private val reservationNumber = 1
 
     private val reason = "회의"
     private val homeBaseStub by lazy {
@@ -48,7 +49,8 @@ class DeleteReservationUseCaseTest {
             representativeId = representativeId,
             reason = reason,
             homeBaseId = homeBaseStub.id,
-            checkStatus = false
+            checkStatus = false,
+            reservationNumber = reservationNumber
         )
     }
 

--- a/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/QueryReservationDetailUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/QueryReservationDetailUseCaseTest.kt
@@ -30,6 +30,7 @@ class QueryReservationDetailUseCaseTest {
 
     private val floor = 3
     private val period = 10
+    private val reservationNumber = 1
 
     private val representativeId = UUID.randomUUID()
     private val userId = UUID.randomUUID()
@@ -49,7 +50,8 @@ class QueryReservationDetailUseCaseTest {
             representativeId = representativeId,
             reason = reason,
             homeBaseId = homeBaseStub.id,
-            checkStatus = false
+            checkStatus = false,
+            reservationNumber = reservationNumber
         )
     }
 
@@ -109,7 +111,8 @@ class QueryReservationDetailUseCaseTest {
             reservationId = reservationStub.id,
             reason = reason,
             checkStatus = false,
-            users = listOf(userResponseStub1, userResponseStub2)
+            users = listOf(userResponseStub1, userResponseStub2),
+            reservationNumber = reservationNumber
         )
     }
 

--- a/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCaseTest.kt
@@ -30,6 +30,7 @@ class UpdateReservationUseCaseTest {
 
     private val floor = 3
     private val period = 10
+    private val reservationNumber = 1
 
     private val representativeId = UUID.randomUUID()
     private val userId = UUID.randomUUID()
@@ -49,7 +50,8 @@ class UpdateReservationUseCaseTest {
             representativeId = representativeId,
             reason = reason,
             homeBaseId = homeBaseStub.id,
-            checkStatus = false
+            checkStatus = false,
+            reservationNumber = reservationNumber
         )
     }
 

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryUserInfoUseCaseTest.kt
@@ -27,6 +27,8 @@ internal class QueryUserInfoUseCaseTest {
 
     private val userId = UUID.randomUUID()
     private val reservationId = UUID.randomUUID()
+    private val reservationNumber = 1
+
 
     private val userStub: User by lazy {
         User(
@@ -49,7 +51,8 @@ internal class QueryUserInfoUseCaseTest {
             representativeId = userId,
             homeBaseId = 1,
             reason = "test",
-            checkStatus = false
+            checkStatus = false,
+            reservationNumber = reservationNumber
         )
     }
 


### PR DESCRIPTION
## 💡 개요
홈베이스 예약 번호 필드 추가

## 📃 작업내용
- 예약 엔티티의 홈베이스와 예약번호 유니크 제약 조건 추가
ex) 층과 교시가 같은 홈베이스에서의 예약 테이블 번호는 유니크 제약 조건을 가짐
- 예약 번호 추가에 따른 usecase, request, response api 수정사항

## 🔀 변경사항
- 홈베이스 예약 request
- 홈베이스 예약 정보 조회 response
- 예약 엔티티 필드

## 🙋‍♂️ 질문사항
테이블에 homeBase와 reservation number 간의 유니크 제약 조건을 추가했으나 더욱 나은 예외처리를 위해
`ReserveHomeBaseUseCase`에서 homebase와 reservation number 간의 존재 여부를 판단하고 예외처리를 진행했습니다.
이에 관해서 어떻게 생각하시는지 의견 남겨주시면 감사하겠습니다.

