### PR TITLE
# 157 내 역할 조회 list role 반환으로 변경

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryMyRoleUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryMyRoleUseCase.kt
@@ -1,7 +1,6 @@
 package team.msg.hiv2.domain.user.application.usecase
 
 import team.msg.hiv2.domain.user.application.service.UserService
-import team.msg.hiv2.domain.user.exception.UserRoleNotFoundException
 import team.msg.hiv2.domain.user.presentation.data.response.UserRoleResponse
 import team.msg.hiv2.global.annotation.usecase.ReadOnlyUseCase
 
@@ -11,8 +10,7 @@ class QueryMyRoleUseCase(
 ) {
     fun execute(): UserRoleResponse {
         val user = userService.queryCurrentUser()
-        val role = user.roles.firstOrNull() ?: throw UserRoleNotFoundException()
 
-        return UserRoleResponse.of(user.id, role)
+        return UserRoleResponse.of(user.id, user.roles)
     }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserRoleResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserRoleResponse.kt
@@ -5,10 +5,10 @@ import java.util.UUID
 
 data class UserRoleResponse(
     val userId: UUID,
-    val role: UserRole
+    val role: MutableList<UserRole>
 ) {
     companion object {
-        fun of(userId: UUID, role: UserRole) = UserRoleResponse(
+        fun of(userId: UUID, role: MutableList<UserRole>) = UserRoleResponse(
             userId = userId,
             role = role
         )

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryMyRoleUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryMyRoleUseCaseTest.kt
@@ -42,7 +42,7 @@ internal class QueryMyRoleUseCaseTest {
     private val responseStub by lazy {
         UserRoleResponse(
             userId = userId,
-            role = userRole
+            role = userStub.roles
         )
     }
 


### PR DESCRIPTION
## 💡 개요
내 역할 조회 list role 반환으로 변경
## 📃 작업내용
내 역할 조회 로직을 단일 role 반환에서 list role 반환으로 변경하였습니다.
테스트 코드도 같이 수정해주었습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
