### PR TITLE
`@EntityGraph`를 사용한 N + 1 해결

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/repository/ReservationRepository.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/repository/ReservationRepository.kt
@@ -1,5 +1,6 @@
 package team.msg.hiv2.domain.reservation.persistence.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -9,7 +10,9 @@ import team.msg.hiv2.domain.reservation.persistence.entity.ReservationJpaEntity
 import java.util.UUID
 
 interface ReservationRepository : CrudRepository<ReservationJpaEntity, UUID> {
+    @EntityGraph(attributePaths = ["homeBase"])
     fun findAllByHomeBase(homeBase: HomeBaseJpaEntity): List<ReservationJpaEntity>
+    @EntityGraph(attributePaths = ["homeBase"])
     fun findAllByHomeBaseIn(homeBases: List<HomeBaseJpaEntity>): List<ReservationJpaEntity>
     @Modifying
     @Query("DELETE FROM ReservationJpaEntity r WHERE r IN :reservations")

--- a/src/main/kotlin/team/msg/hiv2/domain/user/persistence/repository/UserRepository.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/persistence/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package team.msg.hiv2.domain.user.persistence.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.repository.CrudRepository
 import team.msg.hiv2.domain.reservation.persistence.entity.ReservationJpaEntity
 import team.msg.hiv2.domain.user.domain.constant.UserRole
@@ -7,12 +8,16 @@ import team.msg.hiv2.domain.user.persistence.entity.UserJpaEntity
 import java.util.*
 
 interface UserRepository : CrudRepository<UserJpaEntity, UUID> {
+
     fun findByEmail(email: String): UserJpaEntity?
     fun existsByEmail(email: String): Boolean
+    @EntityGraph(attributePaths = ["reservation"])
     fun findAllByReservation(reservation: ReservationJpaEntity): List<UserJpaEntity>
     fun findByIdAndReservation(id: UUID, reservation: ReservationJpaEntity): UserJpaEntity
     fun findAllByNameContaining(keyword: String): List<UserJpaEntity>
     fun findAllByReservationIsNotNull(): List<UserJpaEntity>
+    @EntityGraph(attributePaths = ["reservation"])
     fun findAllByRolesContaining(role: UserRole): List<UserJpaEntity>
+    @EntityGraph(attributePaths = ["reservation"])
     fun findAllByReservationIn(reservations: List<ReservationJpaEntity>): List<UserJpaEntity>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/persistence/repository/UserRepository.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/persistence/repository/UserRepository.kt
@@ -16,7 +16,6 @@ interface UserRepository : CrudRepository<UserJpaEntity, UUID> {
     fun findByIdAndReservation(id: UUID, reservation: ReservationJpaEntity): UserJpaEntity
     fun findAllByNameContaining(keyword: String): List<UserJpaEntity>
     fun findAllByReservationIsNotNull(): List<UserJpaEntity>
-    @EntityGraph(attributePaths = ["reservation"])
     fun findAllByRolesContaining(role: UserRole): List<UserJpaEntity>
     @EntityGraph(attributePaths = ["reservation"])
     fun findAllByReservationIn(reservations: List<ReservationJpaEntity>): List<UserJpaEntity>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-
-
 spring:
   mvc:
     throw-exception-if-no-handler-found: true


### PR DESCRIPTION
## 💡 개요
> N + 1 문제 발생 가능성 해결

Reservation과 User 사이의 조회기능을 수행할 때 fetch join을 사용하지 않고 findAll()을 하기 때문에 
N + 1 문제가 발생할 가능성이 있습니다. Query로 fetch join을 수행하기보단 간단한 조회 기능이기 때문에
`@EntityGraph` 어노테이션을 사용하여 문제를 해결했습니다.

## 📃 작업내용
`@EntityGraph`를 사용한 N + 1 해결

## 🔀 변경사항
- `UserRepository`
  -  findAllByReservation()
  - findAllByReservationIn()
- `ReservationRepository`
  - findAllByHomeBase()
  - findAllByHomeBaseIn

## 🍴 사용방법
사용방법은 변경전과 동일합니다.
