### PR TITLE
# 166 전체 학생 조회 이메일 반환

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/StudentResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/StudentResponse.kt
@@ -5,20 +5,19 @@ import team.msg.hiv2.domain.user.domain.constant.UseStatus
 
 data class StudentResponse(
     val user: UserResponse,
-    val email: String,
     val useStatus: UseStatus
 ) {
     companion object {
         fun of(user: User) = StudentResponse(
             user = UserResponse(
                 userId = user.id,
+                email = user.email,
                 name = user.name,
                 grade = user.grade,
                 classNum = user.classNum,
                 number = user.number,
                 profileImageUrl = user.profileImageUrl
             ),
-            email = user.email,
             useStatus = user.useStatus
         )
     }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/StudentResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/StudentResponse.kt
@@ -5,6 +5,7 @@ import team.msg.hiv2.domain.user.domain.constant.UseStatus
 
 data class StudentResponse(
     val user: UserResponse,
+    val email: String,
     val useStatus: UseStatus
 ) {
     companion object {
@@ -17,6 +18,7 @@ data class StudentResponse(
                 number = user.number,
                 profileImageUrl = user.profileImageUrl
             ),
+            email = user.email,
             useStatus = user.useStatus
         )
     }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserInfoResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserInfoResponse.kt
@@ -13,6 +13,7 @@ class UserInfoResponse(
         fun of(user: User, reservation: ReservationResponse?) = UserInfoResponse(
             user = UserResponse(
                 userId = user.id,
+                email = user.email,
                 name = user.name,
                 grade = user.grade,
                 classNum = user.classNum,

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserResponse.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 
 data class UserResponse(
     val userId: UUID,
+    val email: String,
     val name: String,
     val grade: Int?,
     val classNum: Int?,
@@ -14,6 +15,7 @@ data class UserResponse(
     companion object {
         fun of(user: User) = UserResponse(
             userId = user.id,
+            email = user.email,
             name = user.name,
             grade = user.grade,
             classNum = user.classNum,

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
@@ -1,8 +1,6 @@
 package team.msg.hiv2.domain.user.application.usecase
 
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.*
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mock
@@ -42,6 +40,7 @@ class SearchUserByNameKeywordUseCaseTest {
     private val responseStub by lazy {
         UserResponse(
             userId = userStub.id,
+            email = userStub.email,
             name = userStub.name,
             grade = userStub.grade,
             classNum = userStub.classNum,


### PR DESCRIPTION
## 💡 개요
전체 학생 조회 이메일 반환
## 📃 작업내용
전체 학생 조회에서 이메일을 반환하게 추가해주었습니다.
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
email 필드를 UserResponse에 추가하는 게 좋을 지 따로 studentResponse 에서만 추가하는 게 좋을지 의견 남겨주세요 !