### PR TITLE
170 feat/search user student

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/facade/UserFacade.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/facade/UserFacade.kt
@@ -4,6 +4,7 @@ import team.msg.hiv2.domain.user.presentation.data.request.SearchUserKeywordRequ
 import team.msg.hiv2.domain.user.presentation.data.request.UpdateUserRoleWebRequest
 import team.msg.hiv2.domain.user.presentation.data.request.UpdateUserUseStatusRequest
 import team.msg.hiv2.domain.user.presentation.data.response.AllStudentsResponse
+import team.msg.hiv2.domain.user.presentation.data.response.StudentResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserInfoResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserRoleResponse
@@ -16,4 +17,5 @@ interface UserFacade {
     fun searchUserByNameKeyword(request: SearchUserKeywordRequest): List<UserResponse>
     fun updateUserUseStatus(userId: UUID, request: UpdateUserUseStatusRequest)
     fun updateUserRole(userId: UUID, request: UpdateUserRoleWebRequest)
+    fun searchStudentByNameKeyword(request: SearchUserKeywordRequest): List<StudentResponse>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/facade/UserFacadeImpl.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/facade/UserFacadeImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component
 import team.msg.hiv2.domain.user.application.usecase.QueryAllStudentsUseCase
 import team.msg.hiv2.domain.user.application.usecase.QueryMyRoleUseCase
 import team.msg.hiv2.domain.user.application.usecase.QueryUserInfoUseCase
+import team.msg.hiv2.domain.user.application.usecase.SearchStudentByNameKeywordUseCase
 import team.msg.hiv2.domain.user.application.usecase.SearchUserByNameKeywordUseCase
 import team.msg.hiv2.domain.user.application.usecase.UpdateUserRoleUseCase
 import team.msg.hiv2.domain.user.application.usecase.UpdateUserUseStatusUseCase
@@ -11,6 +12,7 @@ import team.msg.hiv2.domain.user.presentation.data.request.SearchUserKeywordRequ
 import team.msg.hiv2.domain.user.presentation.data.request.UpdateUserRoleWebRequest
 import team.msg.hiv2.domain.user.presentation.data.request.UpdateUserUseStatusRequest
 import team.msg.hiv2.domain.user.presentation.data.response.AllStudentsResponse
+import team.msg.hiv2.domain.user.presentation.data.response.StudentResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserInfoResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserResponse
 import team.msg.hiv2.domain.user.presentation.data.response.UserRoleResponse
@@ -23,7 +25,8 @@ class UserFacadeImpl(
     private val queryMyRoleUseCase: QueryMyRoleUseCase,
     private val searchUserByNameKeywordUseCase: SearchUserByNameKeywordUseCase,
     private val updateUserUseStatusUseCase: UpdateUserUseStatusUseCase,
-    private val updateUserRoleUseCase: UpdateUserRoleUseCase
+    private val updateUserRoleUseCase: UpdateUserRoleUseCase,
+    private val searchStudentByNameKeywordUseCase: SearchStudentByNameKeywordUseCase
 ) : UserFacade {
 
     override fun queryAllStudents(): AllStudentsResponse =
@@ -43,5 +46,8 @@ class UserFacadeImpl(
 
     override fun updateUserRole(userId: UUID, request: UpdateUserRoleWebRequest) =
         updateUserRoleUseCase.execute(userId, request)
+
+    override fun searchStudentByNameKeyword(request: SearchUserKeywordRequest): List<StudentResponse> =
+        searchStudentByNameKeywordUseCase.execute(request)
 
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/service/QueryUserService.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/service/QueryUserService.kt
@@ -15,8 +15,9 @@ interface QueryUserService {
     fun queryUserByIdAndReservation(id: UUID, reservation: Reservation): User
     fun existsUserByEmail(email: String): Boolean
     fun queryCurrentUser(): User
-    fun queryUserByNameContaining(keyword: String): List<User>
+    fun queryUserByNameContainingOrderByEmail(keyword: String): List<User>
     fun queryAllUserByReservationIsNotNull(): List<User>
     fun queryAllUserByRolesContaining(role: UserRole): List<User>
+    fun queryAllUserByNameContainingAndRolesContainingOrderByEmail(keyword: String, role: UserRole): List<User>
     fun queryAllUserByReservationIn(reservations: List<Reservation>): List<User>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/service/QueryUserServiceImpl.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/service/QueryUserServiceImpl.kt
@@ -37,14 +37,17 @@ class QueryUserServiceImpl(
     override fun queryCurrentUser(): User =
         queryUserPort.queryCurrentUser()
 
-    override fun queryUserByNameContaining(keyword: String): List<User> =
-        queryUserPort.queryUserByNameContaining(keyword)
+    override fun queryUserByNameContainingOrderByEmail(keyword: String): List<User> =
+        queryUserPort.queryUserByNameContainingOrderByEmail(keyword)
 
     override fun queryAllUserByReservationIsNotNull(): List<User> =
         queryUserPort.queryAllUserByReservationIsNotNull()
 
     override fun queryAllUserByRolesContaining(role: UserRole): List<User> =
         queryUserPort.queryAllUserByRolesContaining(role)
+
+    override fun queryAllUserByNameContainingAndRolesContainingOrderByEmail(keyword: String,role: UserRole) =
+        queryUserPort.queryAllUserByNameContainingAndRolesContainingOrderByEmail(keyword, role)
 
     override fun queryAllUserByReservationIn(reservations: List<Reservation>): List<User> =
         queryUserPort.queryAllUserByReservationIn(reservations)

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/spi/QueryUserPort.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/spi/QueryUserPort.kt
@@ -15,8 +15,9 @@ interface QueryUserPort {
     fun queryUserByIdAndReservation(id: UUID, reservation: Reservation): User?
     fun existsUserByEmail(email: String): Boolean
     fun queryCurrentUser(): User
-    fun queryUserByNameContaining(keyword: String): List<User>
+    fun queryUserByNameContainingOrderByEmail(keyword: String): List<User>
     fun queryAllUserByReservationIsNotNull(): List<User>
     fun queryAllUserByRolesContaining(role: UserRole): List<User>
+    fun queryAllUserByNameContainingAndRolesContainingOrderByEmail(keyword: String, role: UserRole): List<User>
     fun queryAllUserByReservationIn(reservations: List<Reservation>): List<User>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchStudentByNameKeywordUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchStudentByNameKeywordUseCase.kt
@@ -1,0 +1,18 @@
+package team.msg.hiv2.domain.user.application.usecase
+
+import team.msg.hiv2.domain.user.application.service.UserService
+import team.msg.hiv2.domain.user.domain.constant.UserRole
+import team.msg.hiv2.domain.user.presentation.data.request.SearchUserKeywordRequest
+import team.msg.hiv2.domain.user.presentation.data.response.StudentResponse
+import team.msg.hiv2.global.annotation.usecase.ReadOnlyUseCase
+
+@ReadOnlyUseCase
+class SearchStudentByNameKeywordUseCase(
+    private val userService: UserService
+) {
+
+    fun execute(request: SearchUserKeywordRequest): List<StudentResponse> {
+        val users = userService.queryAllUserByNameContainingAndRolesContainingOrderByEmail(request.keyword, UserRole.ROLE_STUDENT)
+        return users.map { StudentResponse.of(it) }
+    }
+}

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCase.kt
@@ -11,7 +11,7 @@ class SearchUserByNameKeywordUseCase(
 ) {
 
     fun execute(request: SearchUserKeywordRequest): List<UserResponse> =
-        userService.queryUserByNameContaining(request.keyword).map {
+        userService.queryUserByNameContainingOrderByEmail(request.keyword).map {
             UserResponse.of(it)
         }
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/persistence/UserPersistenceAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/persistence/UserPersistenceAdapter.kt
@@ -63,14 +63,17 @@ class UserPersistenceAdapter(
         userMapper.toDomain(userRepository.findByIdOrNull(securityPort.queryCurrentUserId()))
             .let { it ?: throw UserNotFoundException() }
 
-    override fun queryUserByNameContaining(keyword: String): List<User> =
-        userRepository.findAllByNameContaining(keyword).map { userMapper.toDomain(it)!! }
+    override fun queryUserByNameContainingOrderByEmail(keyword: String): List<User> =
+        userRepository.findAllByNameContainingOrderByEmail(keyword).map { userMapper.toDomain(it)!! }
 
     override fun queryAllUserByReservationIsNotNull(): List<User> =
         userRepository.findAllByReservationIsNotNull().map { userMapper.toDomain(it)!! }
 
     override fun queryAllUserByRolesContaining(role: UserRole): List<User> =
         userRepository.findAllByRolesContaining(role).map { userMapper.toDomain(it)!! }
+
+    override fun queryAllUserByNameContainingAndRolesContainingOrderByEmail(keyword: String,role: UserRole): List<User>  =
+        userRepository.findAllByNameContainingAndRolesContainingOrderByEmail(keyword, role).map { userMapper.toDomain(it)!! }
 
     override fun queryAllUserByReservationIn(reservations: List<Reservation>): List<User> =
         userRepository.findAllByReservationIn(reservations.map { reservationMapper.toEntity(it) })

--- a/src/main/kotlin/team/msg/hiv2/domain/user/persistence/repository/UserRepository.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/persistence/repository/UserRepository.kt
@@ -14,9 +14,10 @@ interface UserRepository : CrudRepository<UserJpaEntity, UUID> {
     @EntityGraph(attributePaths = ["reservation"])
     fun findAllByReservation(reservation: ReservationJpaEntity): List<UserJpaEntity>
     fun findByIdAndReservation(id: UUID, reservation: ReservationJpaEntity): UserJpaEntity
-    fun findAllByNameContaining(keyword: String): List<UserJpaEntity>
+    fun findAllByNameContainingOrderByEmail(keyword: String): List<UserJpaEntity>
     fun findAllByReservationIsNotNull(): List<UserJpaEntity>
     fun findAllByRolesContaining(role: UserRole): List<UserJpaEntity>
+    fun findAllByNameContainingAndRolesContainingOrderByEmail(keyword: String, role: UserRole): List<UserJpaEntity>
     @EntityGraph(attributePaths = ["reservation"])
     fun findAllByReservationIn(reservations: List<ReservationJpaEntity>): List<UserJpaEntity>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/UserWebAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/UserWebAdapter.kt
@@ -13,6 +13,7 @@ import team.msg.hiv2.domain.user.presentation.data.response.UserRoleResponse
 import team.msg.hiv2.domain.user.presentation.data.web.UpdateUserUseStatusWebRequest
 import java.util.UUID
 import javax.validation.Valid
+import team.msg.hiv2.domain.user.presentation.data.response.StudentResponse
 
 @RestController
 @RequestMapping("/user")
@@ -61,4 +62,11 @@ class UserWebAdapter(
             )
         )
             .let { ResponseEntity.noContent().build() }
+
+    @GetMapping("/search-student")
+    fun searchStudent(@RequestParam keyword: String): ResponseEntity<List<StudentResponse>> =
+        userFacade.searchStudentByNameKeyword(
+            SearchUserKeywordRequest(keyword)
+        )
+            .let { ResponseEntity.ok(it) }
 }

--- a/src/main/kotlin/team/msg/hiv2/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/team/msg/hiv2/global/security/SecurityConfig.kt
@@ -77,7 +77,8 @@ class SecurityConfig(
             .antMatchers(HttpMethod.GET, "/user/my-page").authenticated()
             .antMatchers(HttpMethod.GET, "/user/students").authenticated()
             .antMatchers(HttpMethod.GET, "/user/my-role").authenticated()
-            .antMatchers(HttpMethod.GET, "/user/search").authenticated()
+            .antMatchers(HttpMethod.GET, "/user/search").hasAnyRole(ADMIN, TEACHER)
+            .antMatchers(HttpMethod.GET, "/user/search-student").hasRole(STUDENT)
             .antMatchers(HttpMethod.PATCH, "/user/{id}").hasAnyRole(ADMIN, TEACHER)
             .antMatchers(HttpMethod.PATCH, "/user/{id}/role").hasRole(ADMIN)
 

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
@@ -64,7 +64,7 @@ class SearchUserByNameKeywordUseCaseTest {
     @Test
     fun `유저 검색 성공`() {
         // given
-        given(userService.queryUserByNameContaining(requestStub.keyword))
+        given(userService.queryUserByNameContainingOrderByEmail(requestStub.keyword))
             .willReturn(listOf(userStub))
 
         // when


### PR DESCRIPTION
## 💡 개요
1. search-student API 추가
2. search api 분리

## 📃 작업내용

### /user
- `/search`: ADMIN, TEACHER만 접근할 수 있으며 모든 유저를 키워드로 검색하는 api (이메일순으로 정렬)
- `/search-student`: STUDENT만 접근할 수 있으며 학생 유저를 키워드로 검색하는 api (이메일순으로 정렬)
- `SearchStudentUseCase` 
  - /search-student api에 사용되는 비즈니스 로직 유즈케이스
  - UserRepository에 **findAllByNameContaingAndRolesContainingOrderByEmail()** 사용

API 변동사항에 따른 Security EndPoint 접근 권한도 변경되었습니다.

## 🔀 변경사항
> UserRepository의 변경은 Query Port, Service의 변동사항과 같습니다.  

findByNameContaining -> findByNameContainigOrderByEmail 정렬 조건 추가
findByNameContainingAndRolesContaining() 메서드 추가

