### PR TITLE
UserResponse, StudentResponse, UserInfoResponse response field 변경

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/StudentResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/StudentResponse.kt
@@ -2,23 +2,30 @@ package team.msg.hiv2.domain.user.presentation.data.response
 
 import team.msg.hiv2.domain.user.domain.User
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
+import team.msg.hiv2.domain.user.domain.constant.UserRole
+import java.util.*
 
 data class StudentResponse(
-    val user: UserResponse,
+    val userId: UUID,
+    val email: String,
+    val name: String,
+    val grade: Int?,
+    val classNum: Int?,
+    val number: Int?,
+    val profileImageUrl: String,
+    val roles: MutableList<UserRole>,
     val useStatus: UseStatus
 ) {
     companion object {
         fun of(user: User) = StudentResponse(
-            user = UserResponse(
-                userId = user.id,
-                email = user.email,
-                name = user.name,
-                grade = user.grade,
-                classNum = user.classNum,
-                number = user.number,
-                profileImageUrl = user.profileImageUrl,
-                roles = user.roles
-            ),
+            userId = user.id,
+            email = user.email,
+            name = user.name,
+            grade = user.grade,
+            classNum = user.classNum,
+            number = user.number,
+            profileImageUrl = user.profileImageUrl,
+            roles = user.roles,
             useStatus = user.useStatus
         )
     }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserInfoResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserInfoResponse.kt
@@ -3,24 +3,31 @@ package team.msg.hiv2.domain.user.presentation.data.response
 import team.msg.hiv2.domain.reservation.presentation.data.response.ReservationResponse
 import team.msg.hiv2.domain.user.domain.User
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
+import team.msg.hiv2.domain.user.domain.constant.UserRole
+import java.util.*
 
 class UserInfoResponse(
-    val user: UserResponse,
+    val userId: UUID,
+    val email: String,
+    val name: String,
+    val grade: Int?,
+    val classNum: Int?,
+    val number: Int?,
+    val profileImageUrl: String,
+    val roles: MutableList<UserRole>,
     val useStatus: UseStatus,
     val reservation: ReservationResponse?
 ) {
     companion object {
         fun of(user: User, reservation: ReservationResponse?) = UserInfoResponse(
-            user = UserResponse(
-                userId = user.id,
-                email = user.email,
-                name = user.name,
-                grade = user.grade,
-                classNum = user.classNum,
-                number = user.number,
-                profileImageUrl = user.profileImageUrl,
-                roles = user.roles
-            ),
+            userId = user.id,
+            email = user.email,
+            name = user.name,
+            grade = user.grade,
+            classNum = user.classNum,
+            number = user.number,
+            profileImageUrl = user.profileImageUrl,
+            roles = user.roles,
             useStatus = user.useStatus,
             reservation = reservation
         )

--- a/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserResponse.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/presentation/data/response/UserResponse.kt
@@ -1,6 +1,7 @@
 package team.msg.hiv2.domain.user.presentation.data.response
 
 import team.msg.hiv2.domain.user.domain.User
+import team.msg.hiv2.domain.user.domain.constant.UseStatus
 import team.msg.hiv2.domain.user.domain.constant.UserRole
 import java.util.UUID
 
@@ -12,7 +13,8 @@ data class UserResponse(
     val classNum: Int?,
     val number: Int?,
     val profileImageUrl: String,
-    val roles: MutableList<UserRole>
+    val roles: MutableList<UserRole>,
+    val useStatus: UseStatus
 ) {
     companion object {
         fun of(user: User) = UserResponse(
@@ -23,7 +25,8 @@ data class UserResponse(
             classNum = user.classNum,
             number = user.number,
             profileImageUrl = user.profileImageUrl,
-            roles = user.roles
+            roles = user.roles,
+            useStatus = user.useStatus
         )
     }
 }

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/SearchUserByNameKeywordUseCaseTest.kt
@@ -38,16 +38,7 @@ class SearchUserByNameKeywordUseCaseTest {
     }
 
     private val responseStub by lazy {
-        UserResponse(
-            userId = userStub.id,
-            email = userStub.email,
-            name = userStub.name,
-            grade = userStub.grade,
-            classNum = userStub.classNum,
-            number = userStub.number,
-            profileImageUrl = userStub.profileImageUrl,
-            roles = userStub.roles
-        )
+        UserResponse.of(userStub)
     }
 
     private val requestStub by lazy {


### PR DESCRIPTION
## 💡 개요
StudentResponse와 UserInfoResponse는 공통으로 들어가는 UserField를 담아둔 UserResponse를 필드로 가지고 있었습니다.
클라이언트단에서 처리가 힘드니 UserResponse를 필드로 갖고있지 않고 전부 필드로 치환하였습니다.

of()함수를 통해 객체를 생성하고 있으니 다른 곳에 변경사항이 생기지는 않았습니다.

## 📃 작업내용
- `UserResponse`
  - useStatus 필드 추가
- `UserInfoResponse`
  - user 관련 필드 추가 
- `StudentInfoResponse`
  - user 관련 필드 추가

> 추가로 STUDENT가 아닌 user의 useStatus는 AVAILABLE로 반환합니다. 

