### PR TITLE
HTTP Request, Response Logging Aspect

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
+++ b/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
@@ -38,8 +38,8 @@ class HttpLoggingAspect {
         val contentType = request.contentType
         val userAgent = request.getHeader("User-Agent")
         val signature: MethodSignature = proceedingJoinPoint.signature as MethodSignature
-        val className: String = signature.declaringType.simpleName
-        val methodName: String = signature.name
+        val className = signature.declaringType.simpleName
+        val methodName = signature.name
         val headerNames = request.headerNames
         val headerSet: MutableSet<String> = HashSet()
 

--- a/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
+++ b/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
@@ -57,14 +57,14 @@ class HttpLoggingAspect {
             is ResponseEntity<*> -> {
                 log.info(
                     "At {}#{} [Response:{}] IP: {}, Session-ID: {}, Headers: {}, Response: {}, Status-Code: {}, Code: {}",
-                    className,methodName,method,ip,sessionId,result.headers,result.body,result.statusCode,code
+                    className, methodName, method, ip,sessionId, result.headers, result.body, result.statusCode, code
                 )
             }
 
             null -> {
                 log.info(
                     "At {}#{} [Response: null] IP: {}, Session-ID: {}, Code: {}",
-                    className,methodName,ip,sessionId,code
+                    className, methodName, ip, sessionId, code
                 )
             }
 

--- a/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
+++ b/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
@@ -38,8 +38,8 @@ class HttpLoggingAspect {
         val contentType = request.contentType
         val userAgent = request.getHeader("User-Agent")
         val signature: MethodSignature = proceedingJoinPoint.signature as MethodSignature
-        val className: String = signature.getDeclaringType().getSimpleName()
-        val methodName: String = signature.getName()
+        val className: String = signature.declaringType.simpleName
+        val methodName: String = signature.name
         val headerNames = request.headerNames
         val headerSet: MutableSet<String> = HashSet()
 

--- a/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
+++ b/src/main/kotlin/team/msg/hiv2/aspect/HttpLoggingAspect.kt
@@ -1,0 +1,89 @@
+package team.msg.hiv2.aspect
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.aspectj.lang.reflect.CodeSignature
+import org.aspectj.lang.reflect.MethodSignature
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import java.util.*
+import kotlin.collections.HashMap
+import kotlin.collections.HashSet
+
+
+@Aspect
+@Component
+class HttpLoggingAspect {
+
+    private val log by lazy { LoggerFactory.getLogger(this.javaClass.simpleName) }
+
+    @Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
+    fun onRequest() {}
+
+    @Around("onRequest()")
+    @Throws(Throwable::class)
+    fun logging(proceedingJoinPoint: ProceedingJoinPoint): Any? {
+        val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+        val ip = request.remoteAddr
+        val method = request.method
+        val uri = request.requestURI
+        val sessionId = request.requestedSessionId
+        val params = request.queryString
+        val contentType = request.contentType
+        val userAgent = request.getHeader("User-Agent")
+        val signature: MethodSignature = proceedingJoinPoint.signature as MethodSignature
+        val className: String = signature.getDeclaringType().getSimpleName()
+        val methodName: String = signature.getName()
+        val headerNames = request.headerNames
+        val headerSet: MutableSet<String> = HashSet()
+
+        while (headerNames.hasMoreElements()) {
+            val headerName = headerNames.nextElement()
+            headerSet.add(headerName)
+        }
+        val code = UUID.randomUUID()
+        log.info(
+            "At {}#{} [Request:{}] IP: {}, Session-ID: {}, URI: {}, Params: {}, Content-Type: {}, User-Agent: {}, Headers: {}, Parameters: {}, Code: {}",
+            className, methodName, method, ip, sessionId, uri, params, contentType, userAgent, headerSet, params(proceedingJoinPoint), code
+        )
+        val result = proceedingJoinPoint.proceed()
+        when (result) {
+            is ResponseEntity<*> -> {
+                log.info(
+                    "At {}#{} [Response:{}] IP: {}, Session-ID: {}, Headers: {}, Response: {}, Status-Code: {}, Code: {}",
+                    className,methodName,method,ip,sessionId,result.headers,result.body,result.statusCode,code
+                )
+            }
+
+            null -> {
+                log.info(
+                    "At {}#{} [Response: null] IP: {}, Session-ID: {}, Code: {}",
+                    className,methodName,ip,sessionId,code
+                )
+            }
+
+            else -> {
+                throw RuntimeException("유효하지 않은 Controller 반환 타입입니다.")
+            }
+        }
+        return result
+    }
+
+    private fun params(joinPoint: JoinPoint): Map<*,*>? {
+        val codeSignature = joinPoint.signature as CodeSignature
+        val parameterNames = codeSignature.parameterNames
+        val args = joinPoint.args
+        val params: MutableMap<String,Any> = HashMap()
+
+        for (i in parameterNames.indices) {
+            params[parameterNames[i]] = args[i]
+        }
+        return params
+    }
+}


### PR DESCRIPTION
## 💡 개요
`@RestController` = WebAdapter를 통해 들어오는 request, response를 로깅하는 aspect를 작성했습니다.

## 📃 작업내용
- `HttpLogggingAspect`
  - response의 타입이 ResponseEntity이면 response 요소를 로깅합니다.
  - null이라면 Response = null 상태와 status code, session id등을 로깅합니다.
  - 그 밖의 타입이라면 `RuntimeException`을 throw합니다.

> 추가로 code는 request, response의 고유한 아이디로 식별하기 위한 용도입니다.

<img width="335" alt="image" src="https://github.com/GSM-MSG/Hi-v2-BackEnd/assets/105429536/f972bd01-f54f-4c66-916a-d042b4659e79">

