### PR TITLE
chore :: reservation id null로 설정

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/DeleteAllReservationByPeriodUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/application/usecase/DeleteAllReservationByPeriodUseCase.kt
@@ -20,7 +20,7 @@ class DeleteAllReservationByPeriodUseCase(
 
         val users = userService.queryAllUserByReservationIn(reservations)
 
+        userService.saveAll(users.map { it.copy(useStatus = UseStatus.AVAILABLE, reservationId = null) })
         reservationService.deleteAllReservationInBatch(reservations)
-        userService.saveAll(users.map { it.copy(useStatus = UseStatus.AVAILABLE) })
     }
 }


### PR DESCRIPTION
## 💡 개요

유저가 reservation을 참조하고있기때문에 reservation 일괄삭제 과정이 처리되지 않는 이슈가 발생했습니다.
user domain의 reservation id와 useStatus를 먼저 null과 AVAILABLE로 처리함으로써 문제를 해결했습니다.

## 📃 작업내용
- DeleteReservationsAllByPeriodUseCase execute()
유저 상태 업데이트 작업을 먼저 처리하도록 수정
예약 일괄 삭제
