### PR TITLE
예약 테이블 상세 삭제 이슈 해결

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/DeleteReservationUseCase.kt
@@ -17,7 +17,7 @@ class DeleteReservationUseCase(
 
         val users = userService.queryAllUserByReservation(reservation)
 
-        userService.saveAll(users.map { it.copy(useStatus = UseStatus.AVAILABLE) })
+        userService.saveAll(users.map { it.copy(useStatus = UseStatus.AVAILABLE, reservationId = null) })
         reservationService.delete(reservation)
     }
 }


### PR DESCRIPTION
## 💡 개요
reservation을 null로 초기화하는 작업이 누락되었습니다.

## 📃 작업내용
reservation 개별 삭제 서비스에서 user reservationId를 null로 설정하여 문제를 해결했습니다.

