### PR TITLE
fix :: user find 하나씩 조회로 수정

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
@@ -20,7 +20,7 @@ class UpdateReservationUseCase(
 
         userService.saveAll(prevUsers.map { it.copy(reservationId = null , useStatus = UseStatus.AVAILABLE) })
 
-        val users = userService.queryAllUserById(request.users)
+        val users = request.users.map { userService.queryUserById(it) }
 
         reservationService.save(reservation.copy(reason = request.reason))
         userService.saveAll(users.map { it.copy(reservationId = reservationId) })

--- a/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCaseTest.kt
@@ -108,6 +108,12 @@ class UpdateReservationUseCaseTest {
         given(reservationService.queryReservationById(requestReservationId))
             .willReturn(reservationStub)
 
+        given(userService.queryUserById(representativeId))
+            .willReturn(userStub1)
+
+        given(userService.queryUserById(userId))
+            .willReturn(userStub2)
+
         // when & then
         assertDoesNotThrow {
             updateReservationUseCase.execute(requestReservationId, requestStub)


### PR DESCRIPTION
## 💡 개요
user가 find 되지 않아 개별적으로 Find해 할당해주도록 수정하였습니다.

## 📃 작업내용
UpdateReservationUseCase execute()
