### PR TITLE
검증 로직을 수정합니다. update reservation 단에서 useStatus 검증 aop는 대표자 검증만

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/aspect/ReservationControlAspect.kt
+++ b/src/main/kotlin/team/msg/hiv2/aspect/ReservationControlAspect.kt
@@ -56,7 +56,6 @@ class ReservationControlAspect(
         val reservation = reservationService.queryReservationById(reservationId)
 
         userValidator.checkRepresentative(currentUser, reservation)
-        userValidator.checkUsersUseStatus(userService.queryAllUserById(request.users))
     }
 
     @Before("delegateRepresentativeUseCasePointcut(reservationId, userId)")

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
@@ -3,6 +3,7 @@ package team.msg.hiv2.domain.reservation.application.usecase
 import team.msg.hiv2.domain.reservation.application.service.ReservationService
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationRequest
 import team.msg.hiv2.domain.user.application.service.UserService
+import team.msg.hiv2.domain.user.application.validator.UserValidator
 import team.msg.hiv2.domain.user.domain.constant.UseStatus
 import team.msg.hiv2.global.annotation.usecase.UseCase
 import java.util.UUID
@@ -10,7 +11,8 @@ import java.util.UUID
 @UseCase
 class UpdateReservationUseCase(
     private val reservationService: ReservationService,
-    private val userService: UserService
+    private val userService: UserService,
+    private val userValidator: UserValidator
 ) {
 
     fun execute(reservationId: UUID, request: UpdateReservationRequest){
@@ -21,6 +23,8 @@ class UpdateReservationUseCase(
         userService.saveAll(prevUsers.map { it.copy(reservationId = null , useStatus = UseStatus.AVAILABLE) })
 
         val users = request.users.map { userService.queryUserById(it) }
+
+        userValidator.checkUsersUseStatus(users)
 
         reservationService.save(reservation.copy(reason = request.reason))
         userService.saveAll(users.map { it.copy(reservationId = reservationId) })

--- a/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCaseTest.kt
@@ -26,6 +26,9 @@ class UpdateReservationUseCaseTest {
     @Mock
     private lateinit var reservationService: ReservationService
 
+    @Mock
+    private lateinit var userValidator: UserValidator
+
     private lateinit var updateReservationUseCase: UpdateReservationUseCase
 
     private val floor = 3
@@ -97,7 +100,7 @@ class UpdateReservationUseCaseTest {
     @BeforeEach
     fun setUp(){
         updateReservationUseCase = UpdateReservationUseCase(
-            reservationService, userService
+            reservationService, userService, userValidator
         )
     }
 


### PR DESCRIPTION
## 💡 개요
UpdateReservationUseCase에서 유저 UseStatus검증 로직 추가
update 검증 aop 검증 로직 수정

## 📃 작업내용
- update 검증 aop작업은 대표자 검증만
- 유즈케이스에서 새로 업데이트할 유저들의 useStatus 검증을 합니다.

