### PR TITLE
# 216 같은 교시 홈베이스 예약 불가 예외 처리

### DIFF
--- a/src/main/kotlin/team/msg/hiv2/aspect/ReservationControlAspect.kt
+++ b/src/main/kotlin/team/msg/hiv2/aspect/ReservationControlAspect.kt
@@ -4,8 +4,12 @@ import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Before
 import org.aspectj.lang.annotation.Pointcut
 import org.springframework.stereotype.Component
+import team.msg.hiv2.domain.homebase.application.service.HomeBaseService
+import team.msg.hiv2.domain.homebase.exception.AlreadyReservedAtSamePeriodException
 import team.msg.hiv2.domain.homebase.presentation.data.request.ReservationHomeBaseRequest
 import team.msg.hiv2.domain.reservation.application.service.ReservationService
+import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationRequest
+import team.msg.hiv2.domain.team.application.service.TeamService
 import team.msg.hiv2.domain.user.application.service.UserService
 import team.msg.hiv2.domain.user.application.validator.UserValidator
 import java.util.*
@@ -15,19 +19,40 @@ import java.util.*
 class ReservationControlAspect(
     private val userService: UserService,
     private val reservationService: ReservationService,
-    private val userValidator: UserValidator
+    private val userValidator: UserValidator,
+    private val homeBaseService: HomeBaseService,
+    private val teamService: TeamService
 ) {
 
     @Pointcut("execution(* team.msg.hiv2.domain.homebase.application.usecase.ReserveHomeBaseUseCase.execute(..)) " +
-            "&& args(floor, period, request) && within(team.msg.hiv2.domain.homebase.application.usecase.ReserveHomeBaseUseCase)")
-    private fun reserveHomeBaseUseCasePointcut(floor: Int, period: Int, request: ReservationHomeBaseRequest) {}
+            "&& args(floor, period, homeBaseNumber, request) && within(team.msg.hiv2.domain.homebase.application.usecase.ReserveHomeBaseUseCase)")
+    private fun reserveHomeBaseUseCasePointcut(floor: Int, period: Int, homeBaseNumber: Int, request: ReservationHomeBaseRequest) {}
+
+    @Pointcut("execution(* team.msg.hiv2.domain.reservation.application.usecase.UpdateReservationUseCase.execute(..)) " +
+            "&& args(reservationId, request) && within(team.msg.hiv2.domain.reservation.application.usecase.UpdateReservationUseCase)")
+    private fun updateReservationUseCasePointcut(reservationId: UUID, request: UpdateReservationRequest) {}
 
     @Pointcut("execution(* team.msg.hiv2.domain.reservation.application.usecase.ExitReservationUseCase.execute(..))" +
             " && args(reservationId) && within(team.msg.hiv2.domain.reservation.application.usecase.ExitReservationUseCase)")
     private fun exitReservationUseCasePointcut(reservationId: UUID){}
 
-    @Before("reserveHomeBaseUseCasePointcut(floor, period, request)")
-    private fun checkAuthorizationReserveHomeBase(floor: Int, period: Int, request: ReservationHomeBaseRequest) {
+    @Before("reserveHomeBaseUseCasePointcut(floor, period, homeBaseNumber, request)")
+    private fun checkReserveHomeBase(floor: Int, period: Int, homeBaseNumber: Int, request: ReservationHomeBaseRequest) {
+        val currentUser = userService.queryCurrentUser()
+
+        userValidator.checkUserUseStatus(currentUser)
+        userValidator.checkUsersUseStatus(userService.queryAllUserById(request.users))
+
+        val homeBases = homeBaseService.queryHomeBaseByPeriod(period)
+        val teamIds = reservationService.queryAllReservationByHomeBaseIn(homeBases).map { reservation -> reservation.teamId }
+        val userIds = teamService.queryAllTeamByIdIn(teamIds).flatMap { team -> team.userIds }
+
+        if (userIds.any { it in request.users })
+            throw AlreadyReservedAtSamePeriodException()
+    }
+
+    @Before("updateReservationUseCasePointcut(reservationId, request)")
+    private fun checkUpdateReservation(reservationId: UUID, request: UpdateReservationRequest) {
         val currentUser = userService.queryCurrentUser()
 
         userValidator.checkUserUseStatus(currentUser)

--- a/src/main/kotlin/team/msg/hiv2/aspect/ReservationControlAspect.kt
+++ b/src/main/kotlin/team/msg/hiv2/aspect/ReservationControlAspect.kt
@@ -4,12 +4,9 @@ import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Before
 import org.aspectj.lang.annotation.Pointcut
 import org.springframework.stereotype.Component
-import team.msg.hiv2.domain.homebase.application.service.HomeBaseService
-import team.msg.hiv2.domain.homebase.exception.AlreadyReservedAtSamePeriodException
 import team.msg.hiv2.domain.homebase.presentation.data.request.ReservationHomeBaseRequest
 import team.msg.hiv2.domain.reservation.application.service.ReservationService
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationRequest
-import team.msg.hiv2.domain.team.application.service.TeamService
 import team.msg.hiv2.domain.user.application.service.UserService
 import team.msg.hiv2.domain.user.application.validator.UserValidator
 import java.util.*
@@ -19,9 +16,7 @@ import java.util.*
 class ReservationControlAspect(
     private val userService: UserService,
     private val reservationService: ReservationService,
-    private val userValidator: UserValidator,
-    private val homeBaseService: HomeBaseService,
-    private val teamService: TeamService
+    private val userValidator: UserValidator
 ) {
 
     @Pointcut("execution(* team.msg.hiv2.domain.homebase.application.usecase.ReserveHomeBaseUseCase.execute(..)) " +
@@ -42,13 +37,6 @@ class ReservationControlAspect(
 
         userValidator.checkUserUseStatus(currentUser)
         userValidator.checkUsersUseStatus(userService.queryAllUserById(request.users))
-
-        val homeBases = homeBaseService.queryHomeBaseByPeriod(period)
-        val teamIds = reservationService.queryAllReservationByHomeBaseIn(homeBases).map { reservation -> reservation.teamId }
-        val userIds = teamService.queryAllTeamByIdIn(teamIds).flatMap { team -> team.userIds }
-
-        if (userIds.any { it in request.users })
-            throw AlreadyReservedAtSamePeriodException()
     }
 
     @Before("updateReservationUseCasePointcut(reservationId, request)")

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/application/service/QueryHomeBaseService.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/application/service/QueryHomeBaseService.kt
@@ -4,6 +4,7 @@ import team.msg.hiv2.domain.homebase.domain.HomeBase
 
 interface QueryHomeBaseService {
 
+    fun queryHomeBaseByPeriod(period: Int): List<HomeBase>
     fun queryHomeBaseByFloorAndPeriod(floor: Int, period: Int): List<HomeBase>
     fun queryHomeBaseByFloorAndPeriodAndHomeBaseNumber(floor: Int, period: Int, homeBaseNumber: Int): HomeBase
     fun queryAllHomeBaseByPeriod(period: Int): List<HomeBase>

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/application/service/QueryHomeBaseServiceImpl.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/application/service/QueryHomeBaseServiceImpl.kt
@@ -9,6 +9,10 @@ import team.msg.hiv2.global.annotation.service.DomainService
 class QueryHomeBaseServiceImpl(
     private val queryHomeBasePort: QueryHomeBasePort
 ) : QueryHomeBaseService {
+
+    override fun queryHomeBaseByPeriod(period: Int): List<HomeBase> =
+        queryHomeBasePort.queryAllHomeBaseByPeriod(period)
+
     override fun queryHomeBaseByFloorAndPeriod(floor: Int, period: Int): List<HomeBase> =
         queryHomeBasePort.queryHomeBaseByFloorAndPeriod(floor, period)
 

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/exception/AlreadyReservedAtSamePeriodException.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/exception/AlreadyReservedAtSamePeriodException.kt
@@ -1,0 +1,6 @@
+package team.msg.hiv2.domain.homebase.exception
+
+import team.msg.hiv2.global.error.ErrorCode
+import team.msg.hiv2.global.error.exception.HiException
+
+class AlreadyReservedAtSamePeriodException : HiException(ErrorCode.ALREADY_RESERVED_AT_SAME_PERIOD)

--- a/src/main/kotlin/team/msg/hiv2/domain/homebase/exception/TooManyUsersException.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/homebase/exception/TooManyUsersException.kt
@@ -1,0 +1,6 @@
+package team.msg.hiv2.domain.homebase.exception
+
+import team.msg.hiv2.global.error.ErrorCode
+import team.msg.hiv2.global.error.exception.HiException
+
+class TooManyUsersException : HiException(ErrorCode.TOO_MANY_USERS_EXCEPTION)

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationService.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationService.kt
@@ -13,5 +13,5 @@ interface QueryReservationService {
     fun queryAllReservation(): List<Reservation>
     fun countReservationByHomeBase(homeBase: HomeBase): Int
     fun existsByHomeBase(homeBase: HomeBase): Boolean
-    fun queryAllReservationByTeams(teams: List<Team>): List<Reservation>
+    fun queryAllReservationByTeamsOrderByTeam(teams: List<Team>): List<Reservation>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationServiceImpl.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/service/QueryReservationServiceImpl.kt
@@ -31,7 +31,7 @@ class QueryReservationServiceImpl(
     override fun existsByHomeBase(homeBase: HomeBase): Boolean =
         queryReservationPort.existsByHomeBase(homeBase)
 
-    override fun queryAllReservationByTeams(teams: List<Team>): List<Reservation> =
-        queryReservationPort.queryAllReservationByTeams(teams)
+    override fun queryAllReservationByTeamsOrderByTeam(teams: List<Team>): List<Reservation> =
+        queryReservationPort.queryAllReservationByTeamsOrderByTeam(teams)
 
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/QueryReservationPort.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/spi/QueryReservationPort.kt
@@ -13,5 +13,5 @@ interface QueryReservationPort {
     fun queryAllReservations(): List<Reservation>
     fun countReservationByHomeBase(homeBase: HomeBase): Int
     fun existsByHomeBase(homeBase: HomeBase): Boolean
-    fun queryAllReservationByTeams(teams: List<Team>): List<Reservation>
+    fun queryAllReservationByTeamsOrderByTeam(teams: List<Team>): List<Reservation>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
@@ -2,10 +2,12 @@ package team.msg.hiv2.domain.reservation.application.usecase
 
 import team.msg.hiv2.domain.homebase.application.service.HomeBaseService
 import team.msg.hiv2.domain.homebase.exception.AlreadyExistReservationException
+import team.msg.hiv2.domain.homebase.exception.TooManyUsersException
 import team.msg.hiv2.domain.reservation.application.service.ReservationService
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationRequest
 import team.msg.hiv2.domain.team.application.service.TeamService
 import team.msg.hiv2.domain.user.application.service.UserService
+import team.msg.hiv2.domain.user.exception.UserNotFoundException
 import team.msg.hiv2.global.annotation.usecase.UseCase
 import java.util.*
 
@@ -21,6 +23,11 @@ class UpdateReservationUseCase(
 
         val reservation = reservationService.queryReservationById(reservationId)
 
+        val homeBase = homeBaseService.queryHomeBaseById(reservation.homeBaseId)
+
+        if (request.users.size > homeBase.maxCapacity)
+            throw TooManyUsersException()
+
         val homeBases = homeBaseService.queryHomeBaseById(reservation.homeBaseId).let { homeBaseService.queryHomeBaseByPeriod(it.period) }
         val teamIds = reservationService.queryAllReservationByHomeBaseIn(homeBases).map { reservation -> reservation.teamId }
         val userIds = teamService.queryAllTeamByIdIn(teamIds).flatMap { team -> team.userIds }
@@ -31,6 +38,10 @@ class UpdateReservationUseCase(
         val team = teamService.queryTeamById(reservation.teamId)
 
         val users = userService.queryAllUserById(request.users)
+
+        if (request.users.size != users.size)
+            throw UserNotFoundException()
+
 
         teamService.save(team.copy(userIds = users.map { it.id }.toMutableList()))
         reservationService.save(reservation.copy(reason = request.reason))

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/application/usecase/UpdateReservationUseCase.kt
@@ -1,5 +1,7 @@
 package team.msg.hiv2.domain.reservation.application.usecase
 
+import team.msg.hiv2.domain.homebase.application.service.HomeBaseService
+import team.msg.hiv2.domain.homebase.exception.AlreadyExistReservationException
 import team.msg.hiv2.domain.reservation.application.service.ReservationService
 import team.msg.hiv2.domain.reservation.presentation.data.request.UpdateReservationRequest
 import team.msg.hiv2.domain.team.application.service.TeamService
@@ -11,16 +13,24 @@ import java.util.*
 class UpdateReservationUseCase(
     private val reservationService: ReservationService,
     private val userService: UserService,
-    private val teamService: TeamService
+    private val teamService: TeamService,
+    private val homeBaseService: HomeBaseService
 ) {
 
     fun execute(reservationId: UUID, request: UpdateReservationRequest) {
 
         val reservation = reservationService.queryReservationById(reservationId)
 
+        val homeBases = homeBaseService.queryHomeBaseById(reservation.homeBaseId).let { homeBaseService.queryHomeBaseByPeriod(it.period) }
+        val teamIds = reservationService.queryAllReservationByHomeBaseIn(homeBases).map { reservation -> reservation.teamId }
+        val userIds = teamService.queryAllTeamByIdIn(teamIds).flatMap { team -> team.userIds }
+
+        if (userIds.containsAll(request.users))
+            throw AlreadyExistReservationException()
+
         val team = teamService.queryTeamById(reservation.teamId)
 
-        val users = request.users.map { userService.queryUserById(it) }
+        val users = userService.queryAllUserById(request.users)
 
         teamService.save(team.copy(userIds = users.map { it.id }.toMutableList()))
         reservationService.save(reservation.copy(reason = request.reason))

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/ReservationPersistenceAdapter.kt
@@ -54,7 +54,7 @@ class ReservationPersistenceAdapter(
     override fun existsByHomeBase(homeBase: HomeBase): Boolean =
         reservationRepository.existsByHomeBase(homeBaseMapper.toEntity(homeBase))
 
-    override fun queryAllReservationByTeams(teams: List<Team>): List<Reservation> =
-        reservationRepository.findAllByTeamIn(teams.map { teamMapper.toEntity(it) }).map { reservationMapper.toDomain(it)!! }
+    override fun queryAllReservationByTeamsOrderByTeam(teams: List<Team>): List<Reservation> =
+        reservationRepository.findAllByTeamInOrderByTeam(teams.map { teamMapper.toEntity(it) }).map { reservationMapper.toDomain(it)!! }
 
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/repository/ReservationRepository.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/reservation/persistence/repository/ReservationRepository.kt
@@ -21,5 +21,5 @@ interface ReservationRepository : JpaRepository<ReservationJpaEntity, UUID> {
     fun countByHomeBase(homeBase: HomeBaseJpaEntity): Int
     fun existsByHomeBase(homeBase: HomeBaseJpaEntity): Boolean
     @EntityGraph(attributePaths = ["homeBase"])
-    fun findAllByTeamIn(teams: List<TeamJpaEntity>): List<ReservationJpaEntity>
+    fun findAllByTeamInOrderByTeam(teams: List<TeamJpaEntity>): List<ReservationJpaEntity>
 }

--- a/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryUserInfoUseCase.kt
+++ b/src/main/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryUserInfoUseCase.kt
@@ -23,7 +23,7 @@ class QueryUserInfoUseCase(
 
         val teams = teamService.queryAllTeamByUserIdsIn(listOf(user.id))
 
-        val reservations = reservationService.queryAllReservationByTeams(teams)
+        val reservations = reservationService.queryAllReservationByTeamsOrderByTeam(teams)
 
         return UserInfoResponse.of(
             user,

--- a/src/main/kotlin/team/msg/hiv2/global/error/ErrorCode.kt
+++ b/src/main/kotlin/team/msg/hiv2/global/error/ErrorCode.kt
@@ -19,6 +19,8 @@ enum class ErrorCode(
     FORBIDDEN_COMMAND_RESERVATION("예약 테이블을 제어할 권한이 없습니다.", 403),
     FORBIDDEN_EXIT_RESERVATION("사용자 수가 2명 이하일 경우 나갈 수 없습니다.", 403),
     ALREADY_EXIST_RESERVATION("이미 예약 되어진 자리입니다.", 403),
+    ALREADY_RESERVED_AT_SAME_PERIOD("이미 같은 교시에 예약된 홈베이스가 존재합니다.", 403),
+    TOO_MANY_USERS_EXCEPTION("인원 수가 홈베이스 최대 인원보다 많습니다.", 403),
 
     // homeBase
     HOME_BASE_NOT_FOUND("홈베이스를 찾을 수 없습니다.", 404),

--- a/src/test/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/homebase/application/usecase/ReserveHomeBaseUseCaseTest.kt
@@ -47,13 +47,7 @@ internal class ReserveHomeBaseUseCaseTest {
     private val teamId2 = UUID.randomUUID()
     private val userId1 = UUID.randomUUID()
     private val userId2 = UUID.randomUUID()
-
-    private val requestStub by lazy {
-        ReservationHomeBaseRequest(
-            mutableListOf(userId1, userId2),
-            reason
-        )
-    }
+    private val userId3 = UUID.randomUUID()
 
     private val homeBaseStub by lazy {
         HomeBase(
@@ -92,8 +86,8 @@ internal class ReserveHomeBaseUseCaseTest {
     private val userStub1 by lazy {
         User(
             id = userId1,
-            email = "test@email",
-            name = "hope",
+            email = "test1@email",
+            name = "hope1",
             grade = 2,
             classNum = 4,
             number = 6,
@@ -117,6 +111,13 @@ internal class ReserveHomeBaseUseCaseTest {
         )
     }
 
+    private val requestStub by lazy {
+        ReservationHomeBaseRequest(
+            mutableListOf(userId1, userId2),
+            reason
+        )
+    }
+
     @BeforeEach
     fun setUp(){
         reserveHomeBaseUseCase = ReserveHomeBaseUseCase(
@@ -127,11 +128,13 @@ internal class ReserveHomeBaseUseCaseTest {
     @Test
     fun `예약 성공`(){
 
-        given(homeBaseService.queryHomeBaseByFloorAndPeriodAndHomeBaseNumber(floor, period, homeBaseNumber)).willReturn(homeBaseStub)
+        given(homeBaseService.queryHomeBaseByFloorAndPeriodAndHomeBaseNumber(floor, period, homeBaseNumber))
+            .willReturn(homeBaseStub)
 
         given(reservationService.existsByHomeBase(homeBaseStub))
+            .willReturn(false)
 
-        given(userService.queryAllUserById(listOf(userId1, userId2)))
+        given(userService.queryAllUserById(requestStub.users))
             .willReturn(listOf(userStub1, userStub2))
 
         given(homeBaseService.queryHomeBaseByPeriod(period))
@@ -139,9 +142,6 @@ internal class ReserveHomeBaseUseCaseTest {
 
         given(reservationService.queryAllReservationByHomeBaseIn(listOf(homeBaseStub)))
             .willReturn(listOf(reservationStub))
-
-        given(teamService.queryAllTeamByIdIn(listOf(teamId2)))
-            .willReturn(listOf(teamStub2))
 
         given(teamService.save(any()))
             .willReturn(teamStub1)

--- a/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryUserInfoUseCaseTest.kt
+++ b/src/test/kotlin/team/msg/hiv2/domain/user/application/usecase/QueryUserInfoUseCaseTest.kt
@@ -17,7 +17,6 @@ import team.msg.hiv2.domain.user.domain.constant.UseStatus
 import team.msg.hiv2.domain.user.domain.constant.UserRole
 import team.msg.hiv2.global.annotation.HiTest
 import java.util.*
-import kotlin.math.max
 
 @HiTest
 internal class QueryUserInfoUseCaseTest {
@@ -98,7 +97,7 @@ internal class QueryUserInfoUseCaseTest {
         given(teamService.queryAllTeamByUserIdsIn(listOf(userId)))
             .willReturn(listOf(teamStub))
 
-        given(reservationService.queryAllReservationByTeams(listOf(teamStub)))
+        given(reservationService.queryAllReservationByTeamsOrderByTeam(listOf(teamStub)))
             .willReturn(listOf(reservationStub))
 
         given(homeBaseService.queryHomeBaseById(reservationStub.homeBaseId))


### PR DESCRIPTION
## 💡 개요
같은 교시 홈베이스 예약 불가 예외 처리
## 📃 작업내용
같은 교시의 홈베이스에는 예약이 불가하도록 예외 처리 해주었습니다.
Update reservation, Reserve homeBase usecase 의 예외 처리를 더 꼼꼼하게 해주었습니다.
마이 페이지 예약 전체조회 정렬을 해주었습니다.